### PR TITLE
fix(bridge): 为 VPCD 客户端模拟逻辑通道

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes follow Keep a Changelog and Semantic Versioning.
 
+## [Unreleased]
+
+### Fixed
+
+- eUICC clients can use the pre-allocated logical channel exposed by a modem VPCD slot.
+  `MANAGE CHANNEL` open and close commands are emulated by the bridge instead of being
+  forwarded to the modem to allocate or release a second channel.
+
 ## [1.3.10] - 2026-08-16
 
 ### Added
@@ -23,7 +31,6 @@ All notable changes follow Keep a Changelog and Semantic Versioning.
   directory listing, the configured modem backend, and the live reader list as pcscd exposes
   it. `install.sh diagnose` keeps its role for active probing (per-reader lpac reads) and
   now includes the bridge log files as well.
-
 ## [1.3.9] - 2026-08-15
 
 ### Fixed

--- a/host/vpcd_modem_bridge.py
+++ b/host/vpcd_modem_bridge.py
@@ -224,6 +224,17 @@ class ModemCard:
         return rewritten, None
 
     def transmit(self, apdu, channel):
+        # VPCD exposes one pre-allocated modem logical channel per slot. A
+        # normal PC/SC lpac client still sends MANAGE CHANNEL OPEN/CLOSE
+        # during eUICC init/cleanup. Do not forward those commands to the
+        # modem (that would allocate/close a different channel); emulate
+        # the already-bound slot channel instead.
+        if len(apdu) >= 5 and apdu[1] == 0x70:
+            if apdu[2] == 0x00 and apdu[3] == 0x00:
+                return bytes((channel, 0x90, 0x00))
+            if apdu[2] == 0x80:
+                return bytes.fromhex("9000")
+            return bytes.fromhex("6A86")
         rewritten, local_response = self.on_channel(apdu, channel)
         if local_response is not None:
             return local_response

--- a/tests/test_modem_backend.py
+++ b/tests/test_modem_backend.py
@@ -5,12 +5,34 @@ from unittest.mock import patch
 
 from host import mdd_orchestrator
 from host.mdd_orchestrator import Orchestrator
-from host.vpcd_modem_bridge import (ModemError, ModemManagerCard,
+from host.vpcd_modem_bridge import (ModemCard, ModemError, ModemManagerCard,
                                     allocate_logical_channels,
                                     logical_channel_metadata, serve_slot)
 
 
 class ModemBackendTests(unittest.TestCase):
+    def test_preallocated_slot_emulates_manage_channel_open_and_close(self):
+        card = ModemCard.__new__(ModemCard)
+        with patch.object(card, "csim") as csim:
+            self.assertEqual(
+                card.transmit(bytes.fromhex("0070000001"), 2),
+                bytes.fromhex("029000"),
+            )
+            self.assertEqual(
+                card.transmit(bytes.fromhex("0070800200"), 2),
+                bytes.fromhex("9000"),
+            )
+        csim.assert_not_called()
+
+    def test_preallocated_slot_rejects_unsupported_manage_channel_parameters(self):
+        card = ModemCard.__new__(ModemCard)
+        with patch.object(card, "csim") as csim:
+            self.assertEqual(
+                card.transmit(bytes.fromhex("0070010001"), 2),
+                bytes.fromhex("6A86"),
+            )
+        csim.assert_not_called()
+
     def test_logical_channel_metadata_exposes_capacity_roles_and_ids(self):
         value = logical_channel_metadata([1, 2, 3])
         self.assertEqual(value["channel_capacity"], 3)


### PR DESCRIPTION
## 摘要

PC/SC 客户端（例如 lpac）在 eUICC 初始化和清理时会发送 MANAGE CHANNEL OPEN/CLOSE。
当前每个 VPCD slot 已经由桥接进程预先绑定一个模块逻辑通道，但原实现仍把这些命令转发给 EC25，导致客户端尝试重复申请或关闭另一条通道。

本 PR 在桥接层本地模拟逻辑通道操作：
- OPEN 返回当前 VPCD slot 已绑定的通道号；
- CLOSE 返回成功，但不释放桥接正在使用的模块通道；
- 非法的通道指令返回明确的状态字。

## 设备环境

- 原生 Debian GNU/Linux 13（trixie），x86_64/amd64
- Quectel EC25 类 USB 蜂窝模块，USB VID:PID 2c7c:0125
- 单个 EC25 模块配合多 Profile eUICC
- PC/SC、pcscd、VPCD 和 lpac
- 通过 ModemManager 或 direct-serial 后端访问模块

## 关联问题

Related to #2

## 安全与隐私影响

- [x] 未包含真实 SIM 身份、电话号码、PIN、Token、激活地址、短信或通话数据。
- [x] 设备操作保持故障关闭，并返回实际状态。
- [x] 用户可见变化已记录在 CHANGELOG.md。
- [x] 已运行 Python 测试和编译检查。

## 验证结果

- tests.test_modem_backend：10 项通过。
- Python 编译检查通过。
- 全量测试在 1.3.10 干净基线上复现了已有的 IdleBackoff 定时测试波动；该失败与本 PR 无关。
- WebUI 构建通过，96 个模块转换完成。

## 参考

- 贡献规范：https://github.com/MddIdd/mdd-sim-gateway/blob/main/CONTRIBUTING.md
- 上游 v1.3.10：https://github.com/MddIdd/mdd-sim-gateway/commit/6ed8765ece1f7d0c6385c4a3a5f06510d1aa63b1