### PR TITLE
fix(esim): 修复 Profile 切换后的线路与读卡器恢复

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes follow Keep a Changelog and Semantic Versioning.
 
+## [Unreleased]
+
+### Fixed
+
+- eSIM profile enable now stops the other saved lines on the same modem, rebuilds only that
+  modem's VPCD bridge, verifies the requested ICCID, refreshes sibling virtual readers and starts
+  only the active profile line.
+
 ## [1.3.10] - 2026-08-16
 
 ### Added
@@ -23,7 +31,6 @@ All notable changes follow Keep a Changelog and Semantic Versioning.
   directory listing, the configured modem backend, and the live reader list as pcscd exposes
   it. `install.sh diagnose` keeps its role for active probing (per-reader lpac reads) and
   now includes the bridge log files as well.
-
 ## [1.3.9] - 2026-08-15
 
 ### Fixed

--- a/control/app/main.py
+++ b/control/app/main.py
@@ -38,6 +38,9 @@ from .runtime import RuntimeRegistry
 STATUS_OK_GRACE_SECONDS = 20
 STATUS_POLL_FAST_SECONDS = 4.0
 STATUS_POLL_HEALTHY_SECONDS = 15.0
+ESIM_PROFILE_REFRESH_ATTEMPTS = int(os.environ.get("MDD_ESIM_PROFILE_REFRESH_ATTEMPTS", "10"))
+ESIM_PROFILE_REFRESH_INTERVAL = float(os.environ.get("MDD_ESIM_PROFILE_REFRESH_INTERVAL", "0.5"))
+ESIM_BRIDGE_RESTART_TIMEOUT = float(os.environ.get("MDD_ESIM_BRIDGE_RESTART_TIMEOUT", "20"))
 # Once Asterisk has completed its own bounded REGISTER transaction and explicitly reports no
 # response, another two minutes of same-session retries cannot repair the stale carrier-side
 # P-CSCF/ESP state.  Rebuild promptly, but leave enough time for the diagnostic worker to capture
@@ -2216,11 +2219,11 @@ def _esim_guard_engine(name: str):
         )
 
 
-async def _esim_refresh_card(name: str, idx: int):
+async def _esim_refresh_card(name: str, idx: int, card_data=None, *, auto_start: bool = True):
     """Re-probe USIM identity after profile enable/disable/download and broadcast."""
     info = hub.cards.get(name) or {"index": idx, "name": name, "present": True}
     try:
-        c = await asyncio.to_thread(sim.read_card, idx)
+        c = card_data if card_data is not None else await asyncio.to_thread(sim.read_card, idx)
         info.update(
             present=True, index=idx, name=name,
             iccid=c.iccid, imsi=c.imsi, mcc=c.mcc, mnc=c.mnc,
@@ -2243,9 +2246,152 @@ async def _esim_refresh_card(name: str, idx: int):
         info.update(index=idx, name=name, present=True)
     hub.cards[name] = info
     await hub.broadcast({"type": "cards", "cards": _client_cards()})
-    if info.get("matched"):
+    if auto_start and info.get("matched"):
         asyncio.create_task(_auto_start_hotplugged_line(str(info["matched"])))
     return info
+
+
+async def _esim_refresh_virtual_cards(name: str):
+    """Refresh cached siblings of a modem VPCD reader after an eUICC switch.
+
+    The profile switch is one physical-card operation, but pcscd exposes one cached card entry
+    per modem logical channel. Refreshing only the LPA reader leaves the SWu/AMI entries with the
+    old ICCID, so the start guard can reject a valid newly active profile.
+    """
+    identity = _modem_identity_for_reader(name)
+    hardware_id = str((identity or {}).get("hardware_id") or "")
+    if not hardware_id:
+        return
+    readers = await asyncio.to_thread(sim.list_readers)
+    for sibling, cached in list(hub.cards.items()):
+        if sibling == name or not cached.get("present"):
+            continue
+        sibling_identity = _modem_identity_for_reader(sibling)
+        if str((sibling_identity or {}).get("hardware_id") or "") != hardware_id:
+            continue
+        try:
+            sibling_idx = readers.index(sibling)
+            card = await asyncio.to_thread(sim.read_card, sibling_idx)
+            await _esim_refresh_card(sibling, sibling_idx, card_data=card, auto_start=False)
+        except Exception as exc:  # noqa
+            log.warning("post-LPA virtual reader refresh failed reader=%s: %s", sibling, exc)
+
+
+def _esim_bridge_request_paths() -> tuple[str, str]:
+    root = os.path.join(cfg.DATA_DIR, "orchestrator")
+    return (os.path.join(root, "bridge-restart-request.json"),
+            os.path.join(root, "bridge-restart-status.json"))
+
+
+async def _esim_restart_modem_bridge(name: str, timeout: float = ESIM_BRIDGE_RESTART_TIMEOUT) -> int:
+    """Ask the host orchestrator to recycle the VPCD bridge for this generated reader."""
+    identity = _modem_identity_for_reader(name)
+    hardware_id = str((identity or {}).get("hardware_id") or "")
+    readers = await asyncio.to_thread(sim.list_readers)
+    if not hardware_id:
+        if name not in readers:
+            raise HTTPException(503, "reader disappeared after eSIM profile refresh")
+        return readers.index(name)
+
+    request_path, status_path = _esim_bridge_request_paths()
+    request_id = f"esim-{int(time.time() * 1000)}-{random.randrange(1_000_000):06d}"
+    os.makedirs(os.path.dirname(request_path), mode=0o700, exist_ok=True)
+    temporary = request_path + ".tmp"
+    with open(temporary, "w", encoding="utf-8") as handle:
+        json.dump({"request_id": request_id, "device_id": hardware_id,
+                   "requested_at": int(time.time())}, handle)
+    os.chmod(temporary, 0o600)
+    os.replace(temporary, request_path)
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        status = _read_json_file(status_path)
+        if status.get("request_id") == request_id:
+            if status.get("state") != "completed":
+                raise HTTPException(503, status.get("error") or "VPCD bridge rebuild failed")
+            break
+        await asyncio.sleep(.25)
+    else:
+        raise HTTPException(503, "timed out waiting for VPCD bridge rebuild")
+
+    while time.monotonic() < deadline:
+        readers = await asyncio.to_thread(sim.list_readers)
+        if name in readers:
+            return readers.index(name)
+        await asyncio.sleep(.25)
+    raise HTTPException(503, "VPCD reader did not re-enumerate after eSIM profile refresh")
+
+
+async def _esim_recover_profile_switch(name: str, iccid: str) -> dict:
+    """Rebuild the modem reader, prove the active ICCID, and start only its line."""
+    idx = await _esim_restart_modem_bridge(name)
+    last_error = ""
+    info = None
+    for _attempt in range(max(1, ESIM_PROFILE_REFRESH_ATTEMPTS)):
+        try:
+            c = await asyncio.to_thread(sim.read_card, idx)
+            if str(c.iccid or "") != str(iccid):
+                last_error = f"active ICCID is {c.iccid or 'unknown'}, expected {iccid}"
+            else:
+                info = await _esim_refresh_card(name, idx, card_data=c, auto_start=False)
+                await _esim_refresh_virtual_cards(name)
+                break
+        except Exception as exc:  # noqa
+            last_error = str(exc)
+        await asyncio.sleep(ESIM_PROFILE_REFRESH_INTERVAL)
+    if info is None:
+        raise HTTPException(503, f"eSIM profile did not become active: {last_error}")
+
+    target = _match_instance_by_iccid(iccid)
+    if not target:
+        raise HTTPException(409, f"no MDD instance configured for ICCID {iccid}")
+    hardware_id = str((_modem_identity_for_reader(name) or {}).get("hardware_id") or "")
+    for inst in cfg.list_instances():
+        same_modem = hardware_id and str(inst.get("imei_source_device_id") or "") == hardware_id
+        if not same_modem:
+            continue
+        wanted = str(inst.get("id")) == str(target.get("id"))
+        if bool(inst.get("enabled", True)) != wanted:
+            await asyncio.to_thread(cfg.upsert_instance, {"id": str(inst["id"]),
+                                                           "enabled": wanted})
+        if not wanted and await asyncio.to_thread(engine.is_running, str(inst["id"])):
+            await asyncio.to_thread(engine.stop, str(inst["id"]))
+            await hub.drop_ami(str(inst["id"]))
+    egress.publish()
+    await api_instance_start(str(target["id"]))
+    return info
+
+
+async def _esim_prepare_profile_switch(name: str) -> dict[str, bool]:
+    """Stop and disable all saved lines belonging to one modem before LPA runs."""
+    hardware_id = str((_modem_identity_for_reader(name) or {}).get("hardware_id") or "")
+    previous = {}
+    if not hardware_id:
+        return previous
+    for inst in cfg.list_instances():
+        if str(inst.get("imei_source_device_id") or "") != hardware_id:
+            continue
+        iid = str(inst["id"])
+        previous[iid] = bool(inst.get("enabled", True))
+        if previous[iid]:
+            await asyncio.to_thread(cfg.upsert_instance, {"id": iid, "enabled": False})
+        if await asyncio.to_thread(engine.is_running, iid):
+            await asyncio.to_thread(engine.stop, iid)
+            await hub.drop_ami(iid)
+    if previous:
+        egress.publish()
+    return previous
+
+
+def _esim_restore_profile_switch(previous: dict[str, bool]):
+    changed = False
+    for iid, enabled in previous.items():
+        inst = cfg.get_instance(iid)
+        if inst and bool(inst.get("enabled", True)) != enabled:
+            cfg.upsert_instance({"id": iid, "enabled": enabled})
+            changed = True
+    if changed:
+        egress.publish()
 
 
 async def _esim_run(name: str, idx: int, coro, *, refresh: bool = False):
@@ -2368,6 +2514,14 @@ def _card_identity_mismatch(inst: dict) -> dict | None:
     want = (inst.get("iccid") or "").strip()
     if not want:
         return None
+    swu_name = (inst.get("swu_reader") or "").strip()
+    if swu_name:
+        for c in hub.cards.values():
+            if c.get("name") != swu_name or not c.get("present"):
+                continue
+            got = (c.get("iccid") or "").strip()
+            if got and got != want:
+                return {"reader": swu_name, "iccid": got}
     if _reader_index_for_instance(inst) is not None:
         return None      # this line's SIM/profile is present somewhere — all good
     # Prefer the stable USB port binding when present; fall back to stored index.
@@ -2637,6 +2791,9 @@ def _device_for_card(card_info: dict, cards: list[dict] | None = None) -> tuple[
     if card_info.get("hardware_kind") == "modem" and hardware_id:
         return hardware_id, "modem"
     name = str(card_info.get("name") or "")
+    hardware_id = hardware_id or device_state.vpcd_modem_hardware_id(name)
+    if hardware_id:
+        return hardware_id, "modem"
     port = str(card_info.get("reader_port") or "")
     for device_id, candidate in device_state.native_reader_devices(cards).items():
         if ((name and candidate.get("name") == name)
@@ -4687,9 +4844,15 @@ async def api_esim_enable(iccid: str, body: dict | None = None):
     se = await asyncio.to_thread(
         _esim_resolve_se, name, idx, body.get("se_id") or body.get("seId"), body.get("aid"),
         require=True)
-    await _esim_run(
-        name, idx, lpa.profile_enable(name, iccid, aid=se.get("aid")), refresh=True)
+    previous = await _esim_prepare_profile_switch(name)
+    try:
+        await _esim_run(
+            name, idx, lpa.profile_enable(name, iccid, aid=se.get("aid")))
+    except Exception:
+        await asyncio.to_thread(_esim_restore_profile_switch, previous)
+        raise
     await asyncio.to_thread(_esim_cache_update_profile, iccid, state="enabled")
+    await _esim_recover_profile_switch(name, iccid)
     return {"ok": True, "iccid": iccid, "se_id": se["id"], "card": hub.cards.get(name)}
 
 

--- a/host/mdd_orchestrator.py
+++ b/host/mdd_orchestrator.py
@@ -438,6 +438,8 @@ class Orchestrator:
         self.hw_state_path = self.root / "hardware-state.json"
         self.device_desired_path = self.root / "devices-desired.json"
         self.device_status_path = self.root / "devices-status.json"
+        self.bridge_restart_path = self.root / "bridge-restart-request.json"
+        self.bridge_restart_status_path = self.root / "bridge-restart-status.json"
         self.generated = self.root / "sing-box.json"
         self.xray_generated = self.root / "xray.json"
         self.cache = self.root / "subscription.yaml"
@@ -537,6 +539,46 @@ class Orchestrator:
         self._serial_mode = False
         # device id -> the exact command its bridge runs, for the support bundle.
         self._bridge_commands: dict[str, list] = {}
+
+    def process_bridge_restart_request(self):
+        """Recycle one modem bridge after an eUICC profile refresh.
+
+        eUICC REFRESH can leave a VPCD child with a stale logical-channel selection. The
+        control plane requests only that child be recreated; sing-box, ModemManager and other
+        modem bridges stay untouched.
+        """
+        request = read_json(self.bridge_restart_path)
+        if not request:
+            return
+        try:
+            self.bridge_restart_path.unlink()
+        except OSError:
+            pass
+        request_id = str(request.get("request_id") or "")
+        device_id = str(request.get("device_id") or "")
+        if not request_id or not device_id:
+            atomic_json(self.bridge_restart_status_path, {
+                "state": "failed", "error": "request_id and device_id are required",
+                "updated_at": int(time.time())})
+            return
+        self.root.mkdir(parents=True, exist_ok=True)
+        (self.root / "pcsc-maintenance").write_text(str(int(time.time())), encoding="ascii")
+        proc = self.bridges.pop(device_id, None)
+        self.bridge_ports.pop(device_id, None)
+        self._bridge_started.pop(device_id, None)
+        self._bridge_failures.pop(device_id, None)
+        was_running = bool(proc and proc.poll() is None)
+        if was_running:
+            proc.terminate()
+            try:
+                proc.wait(8)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
+        atomic_json(self.bridge_restart_status_path, {
+            "state": "completed", "request_id": request_id, "device_id": device_id,
+            "was_running": was_running, "updated_at": int(time.time())})
+        self.log(f"recycled VPCD bridge for eUICC profile refresh: {device_id}")
 
     @staticmethod
     def service_active(name: str) -> bool:
@@ -2357,6 +2399,7 @@ class Orchestrator:
         self.root.mkdir(parents=True, exist_ok=True)
         while not self.stop:
             self.process_update_request()
+            self.process_bridge_restart_request()
             self.retire_obsolete_services()
             self.reconcile_timezone()
             desired = read_json(self.desired_path)
@@ -2449,7 +2492,8 @@ class Orchestrator:
         """Cheap change detector for the documents an operator action writes."""
         stamps = []
         for path in (self.desired_path, self.device_desired_path,
-                     self.data / "config.yaml", self.reselect_path):
+                     self.data / "config.yaml", self.reselect_path,
+                     self.bridge_restart_path):
             try:
                 stamps.append(path.stat().st_mtime)
             except OSError:

--- a/tests/test_card_identity.py
+++ b/tests/test_card_identity.py
@@ -1,0 +1,28 @@
+import unittest
+from unittest.mock import patch
+
+from control.app import main
+
+
+class CardIdentityGuardTests(unittest.TestCase):
+    def test_same_swu_reader_name_with_different_iccid_is_a_mismatch(self):
+        instance = {
+            "id": "line-target",
+            "iccid": "profile-target",
+            "swu_reader": "slot 1",
+            "reader_index": 1,
+            "reader_port": "1-2",
+        }
+        live_card = {
+            "name": "slot 1",
+            "index": 1,
+            "present": True,
+            "iccid": "profile-other",
+            "reader_port": "1-2",
+        }
+
+        with patch.object(main.hub, "cards", {"slot-1": live_card}):
+            mismatch = main._card_identity_mismatch(instance)
+
+        self.assertIsNotNone(mismatch)
+        self.assertEqual(mismatch["iccid"], live_card["iccid"])

--- a/tests/test_country_egress.py
+++ b/tests/test_country_egress.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import os
 import time
 import io
 import tempfile
@@ -785,6 +786,8 @@ class IdleBackoffTests(unittest.TestCase):
                 clock[0] += seconds
                 if len(slept) == 2:              # an operator saves settings mid-wait
                     app.desired_path.write_text('{"changed": true}')
+                    os.utime(app.desired_path, ns=(2_000_000_000_000,
+                                                   2_000_000_000_000))
 
             with patch("host.mdd_orchestrator.time.sleep", fake_sleep), \
                     patch("host.mdd_orchestrator.time.time", lambda: clock[0]):
@@ -833,7 +836,7 @@ class IdleBackoffTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp:
             app = self._app(temp)
             # None of them exist yet on a fresh install.
-            self.assertEqual(len(app._input_mtimes()), 6)
+            self.assertEqual(len(app._input_mtimes()), 7)
 
 
 class HotplugResponsivenessTests(unittest.TestCase):
@@ -853,4 +856,4 @@ class HotplugResponsivenessTests(unittest.TestCase):
             self.assertNotEqual(two_devices, three_devices,
                                 "a newly plugged modem must end the backoff")
             # A platform without a USB tree still returns a stable shape.
-            self.assertEqual(len(app._input_mtimes()), 6)
+            self.assertEqual(len(app._input_mtimes()), 7)

--- a/tests/test_line_lifecycle.py
+++ b/tests/test_line_lifecycle.py
@@ -1,6 +1,7 @@
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 from control.app import config, engine, main
@@ -175,6 +176,134 @@ class BackgroundStartGuardTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result["restarted"], ["1"])
         stop.assert_called_once_with("1")
         start.assert_called_once_with(running, {}, dev_mounts=False)
+
+
+class ESimProfileSwitchRecoveryTests(unittest.IsolatedAsyncioTestCase):
+    def test_raw_vpcd_card_resolves_modem_imei_from_reader_name(self):
+        card = {"name": "VoWiFi Modem modem-1 00 00", "present": True,
+                "iccid": "profile-target"}
+        with patch.object(main, "_device_identities", return_value={
+                "modem-1": {"hardware_id": "modem-1", "imei": "000000000000001"}}):
+            imei, device_id, device_type = main._hardware_imei_for_card(card, [card])
+
+        self.assertEqual(imei, "000000000000001")
+        self.assertEqual(device_id, "modem-1")
+        self.assertEqual(device_type, "modem")
+
+    async def test_recovery_enables_and_starts_only_the_live_profile(self):
+        reader = "VoWiFi Modem modem-1 00 00"
+        lines = {
+            "1": {"id": "1", "iccid": "profile-old", "enabled": True,
+                  "imei_source_device_id": "modem-1"},
+            "2": {"id": "2", "iccid": "profile-target", "enabled": False,
+                  "imei_source_device_id": "modem-1"},
+            "3": {"id": "3", "iccid": "profile-other", "enabled": True,
+                  "imei_source_device_id": "modem-2"},
+        }
+
+        def list_instances():
+            return [dict(value) for value in lines.values()]
+
+        def get_instance(iid):
+            value = lines.get(str(iid))
+            return dict(value) if value else None
+
+        def upsert(value):
+            iid = str(value["id"])
+            lines[iid] = {**lines[iid], **value}
+            return dict(lines[iid])
+
+        cards = {}
+        with patch.object(main, "_esim_restart_modem_bridge", new=AsyncMock(return_value=0)), \
+                patch.object(main.sim, "read_card", side_effect=[
+                    RuntimeError("ADF.USIM select failed"),
+                    SimpleNamespace(iccid="profile-target", imsi="imsi-target",
+                                    mcc="234", mnc="15", mnc_len=2,
+                                    pin_enabled=False, pin_tries=3, smsc="",
+                                    carrier_identity={}),
+                ]), \
+                patch.object(main.cfg, "list_instances", side_effect=list_instances), \
+                patch.object(main.cfg, "get_instance", side_effect=get_instance), \
+                patch.object(main.cfg, "upsert_instance", side_effect=upsert), \
+                patch.object(main.engine, "is_running", return_value=False), \
+                patch.object(main, "_carrier_identity_update", return_value={}), \
+                patch.object(main.hub, "cards", cards), \
+                patch.object(main.hub, "broadcast", new=AsyncMock()), \
+                patch.object(main.egress, "publish") as publish, \
+                patch.object(main, "api_instance_start", new=AsyncMock()) as start, \
+                patch.object(main.asyncio, "create_task") as create_task, \
+                patch.object(main.asyncio, "sleep", new=AsyncMock()):
+            result = await main._esim_recover_profile_switch(reader, "profile-target")
+
+        self.assertEqual(result["iccid"], "profile-target")
+        self.assertFalse(lines["1"]["enabled"])
+        self.assertTrue(lines["2"]["enabled"])
+        self.assertTrue(lines["3"]["enabled"])
+        publish.assert_called_once()
+        start.assert_awaited_once_with("2")
+        create_task.assert_not_called()
+
+    async def test_recovery_fails_closed_when_target_profile_never_appears(self):
+        reader = "VoWiFi Modem modem-1 00 00"
+        stale = SimpleNamespace(iccid="profile-old", imsi="imsi-old", mcc="234", mnc="15",
+                                mnc_len=2, pin_enabled=False, pin_tries=3, smsc="",
+                                carrier_identity={})
+        with patch.object(main, "_esim_restart_modem_bridge", new=AsyncMock(return_value=0)), \
+                patch.object(main.sim, "read_card", return_value=stale), \
+                patch.object(main.sim, "list_readers", return_value=[reader]), \
+                patch.object(main.asyncio, "sleep", new=AsyncMock()), \
+                patch.object(main, "ESIM_PROFILE_REFRESH_ATTEMPTS", 2):
+            with self.assertRaises(main.HTTPException) as raised:
+                await main._esim_recover_profile_switch(reader, "profile-target")
+
+        self.assertEqual(raised.exception.status_code, 503)
+
+    async def test_recovery_refreshes_all_virtual_readers_for_the_modem(self):
+        reader = "VoWiFi Modem modem-1 00 00"
+        siblings = [reader, "VoWiFi Modem modem-1 00 01", "VoWiFi Modem modem-1 00 02"]
+        target_card = SimpleNamespace(
+            iccid="profile-target", imsi="imsi-target", mcc="234", mnc="15",
+            mnc_len=2, pin_enabled=False, pin_tries=3, smsc="", carrier_identity={})
+        lines = {
+            "1": {"id": "1", "iccid": "profile-old", "enabled": True,
+                  "imei_source_device_id": "modem-1"},
+            "2": {"id": "2", "iccid": "profile-target", "enabled": False,
+                  "imei_source_device_id": "modem-1"},
+        }
+        cards = {name: {"name": name, "index": index, "present": True,
+                        "iccid": "profile-old"}
+                 for index, name in enumerate(siblings)}
+
+        def list_instances():
+            return [dict(value) for value in lines.values()]
+
+        def get_instance(iid):
+            value = lines.get(str(iid))
+            return dict(value) if value else None
+
+        def upsert(value):
+            iid = str(value["id"])
+            lines[iid] = {**lines[iid], **value}
+            return dict(lines[iid])
+
+        with patch.object(main, "_esim_restart_modem_bridge", new=AsyncMock(return_value=0)), \
+                patch.object(main.sim, "read_card", return_value=target_card), \
+                patch.object(main.sim, "list_readers", return_value=siblings), \
+                patch.object(main.cfg, "list_instances", side_effect=list_instances), \
+                patch.object(main.cfg, "get_instance", side_effect=get_instance), \
+                patch.object(main.cfg, "upsert_instance", side_effect=upsert), \
+                patch.object(main.engine, "is_running", return_value=False), \
+                patch.object(main, "_carrier_identity_update", return_value={}), \
+                patch.object(main, "_modem_identity_for_reader",
+                             return_value={"hardware_id": "modem-1"}), \
+                patch.object(main.hub, "cards", cards), \
+                patch.object(main.hub, "broadcast", new=AsyncMock()), \
+                patch.object(main.egress, "publish"), \
+                patch.object(main, "api_instance_start", new=AsyncMock()), \
+                patch.object(main.asyncio, "sleep", new=AsyncMock()):
+            await main._esim_recover_profile_switch(reader, "profile-target")
+
+        self.assertEqual({cards[name]["iccid"] for name in siblings}, {"profile-target"})
 
 
 class StatusActivityTests(unittest.TestCase):

--- a/tests/test_modem_backend.py
+++ b/tests/test_modem_backend.py
@@ -1,7 +1,9 @@
+import tempfile
 import threading
 import unittest
+from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from host import mdd_orchestrator
 from host.mdd_orchestrator import Orchestrator
@@ -11,6 +13,33 @@ from host.vpcd_modem_bridge import (ModemError, ModemManagerCard,
 
 
 class ModemBackendTests(unittest.TestCase):
+    def test_bridge_restart_request_recycles_only_the_requested_modem(self):
+        with tempfile.TemporaryDirectory() as temp:
+            data = Path(temp) / "data"
+            repo = Path(temp) / "repo"
+            app = Orchestrator(data, repo)
+            target = Mock()
+            target.poll.return_value = None
+            other = Mock()
+            other.poll.return_value = None
+            app.bridges = {"modem-1": target, "modem-2": other}
+            app.bridge_ports = {"modem-1": 15360, "modem-2": 15616}
+            app.root.mkdir(parents=True)
+            mdd_orchestrator.atomic_json(app.bridge_restart_path, {
+                "request_id": "switch-1", "device_id": "modem-1"})
+
+            app.process_bridge_restart_request()
+
+            target.terminate.assert_called_once()
+            target.wait.assert_called_once_with(8)
+            other.terminate.assert_not_called()
+            self.assertNotIn("modem-1", app.bridges)
+            self.assertIn("modem-2", app.bridges)
+            self.assertTrue((app.root / "pcsc-maintenance").exists())
+            status = mdd_orchestrator.read_json(app.bridge_restart_status_path)
+            self.assertEqual(status["state"], "completed")
+            self.assertEqual(status["request_id"], "switch-1")
+
     def test_logical_channel_metadata_exposes_capacity_roles_and_ids(self):
         value = logical_channel_metadata([1, 2, 3])
         self.assertEqual(value["channel_capacity"], 3)


### PR DESCRIPTION
## 摘要

切换同一 EC25/eUICC 上的 eSIM Profile 时，LPA REFRESH 会使卡片短暂表现为移除并重新插入。原流程只刷新执行 LPA 操作的读卡器，其他 VPCD 逻辑通道可能继续缓存旧 ICCID，导致新 Profile 的线路无法启动或界面状态不一致。

本 PR：
- 在切换前停止同一模块上保存的其他线路；
- 只请求重建目标 EC25 的 VPCD 桥接，不影响其他模块；
- 切换后验证实际 ICCID 与请求的 Profile 一致；
- 刷新同一模块的其他 VPCD 虚拟读卡器；
- 只重新启用目标 Profile 对应的线路。

## 设备环境

- 原生 Debian GNU/Linux 13（trixie），x86_64/amd64
- Quectel EC25 类 USB 蜂窝模块，USB VID:PID 2c7c:0125
- 单个 EC25 模块配合多 Profile eUICC
- PC/SC、pcscd、VPCD、lpac
- MDD Sim Gateway：问题在基于 v1.3.9 的环境中复现，本修复已基于 v1.3.10 验证

## 关联问题

Fixes #3

## 安全与隐私影响

- [x] 未包含真实 ICCID、EID、IMEI、电话号码、激活码或凭据。
- [x] 请求的 Profile 必须通过实际 ICCID 验证后才会继续。
- [x] 只重启目标模块的桥接，避免扩大设备中断范围。
- [x] 用户可见变化已记录在 CHANGELOG.md。
- [x] 已增加 Profile 切换、卡身份和线路生命周期测试。

## 验证结果

- Python 全量测试：479 项通过。
- Python 编译检查通过。
- WebUI 构建通过，96 个模块转换完成。

## 参考

- #1：ModemManager 和串口后端相关问题
- #2：Virtual PCD 与模块读卡器冲突
- 贡献规范：https://github.com/MddIdd/mdd-sim-gateway/blob/main/CONTRIBUTING.md
- 上游 v1.3.10：https://github.com/MddIdd/mdd-sim-gateway/commit/6ed8765ece1f7d0c6385c4a3a5f06510d1aa63b1