### PR TITLE
fix(modem): 修复直连串口 VoWiFi 状态收敛

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes follow Keep a Changelog and Semantic Versioning.
 
+## [Unreleased]
+
+### Fixed
+
+- Flight-mode VoWiFi can settle on a direct-serial SIM bridge without keeping ModemManager
+  active. Repeated ModemManager `PhoneFailure` channel-allocation errors also fall back to the
+  direct serial path while cellular data remains disabled.
+
 ## [1.3.10] - 2026-08-16
 
 ### Added
@@ -23,7 +31,6 @@ All notable changes follow Keep a Changelog and Semantic Versioning.
   directory listing, the configured modem backend, and the live reader list as pcscd exposes
   it. `install.sh diagnose` keeps its role for active probing (per-reader lpac reads) and
   now includes the bridge log files as well.
-
 ## [1.3.9] - 2026-08-15
 
 ### Fixed

--- a/host/mdd_orchestrator.py
+++ b/host/mdd_orchestrator.py
@@ -665,7 +665,8 @@ class Orchestrator:
                 present and (target_data_active != observed_data_active or
                              (backend_active and radio_enabled is not None and
                               bool(wanted.get("flight_mode")) == radio_enabled) or
-                             (bool(desired_devices) and not backend_active))))
+                             (not bool(wanted.get("flight_mode")) and
+                              not backend_active))))
             devices[device_id] = {
                 "id": device_id,
                 "name": assignment.get("name") or "USB modem",
@@ -681,7 +682,8 @@ class Orchestrator:
                            # Which path is carrying SIM traffic, so a modem serving VoWiFi
                            # without any cellular capability is not read as half-broken.
                            "vowifi_backend": ("direct-serial"
-                                              if degraded or self._serial_mode else
+                                              if degraded or self._serial_mode or
+                                              (vowifi_actual and not mm_active) else
                                               "modemmanager" if vowifi_actual else ""),
                            # False only in configured serial mode: cellular is then a
                            # capability this host does not have, and the control plane
@@ -833,6 +835,14 @@ class Orchestrator:
         self._bridge_failures[hwid] = {"count": count, "at": time.time(), "reason": reason,
                                        "returncode": proc.returncode,
                                        "uptime": round(uptime, 1)}
+        lowered = reason.casefold()
+        if count >= 3 and "logical channel allocation failed" in lowered and \
+                ("phonefailure" in lowered or "phone failure" in lowered):
+            self._degraded[hwid] = (
+                "ModemManager owns the modem but its AT command path cannot access the SIM; "
+                "using direct serial for the VoWiFi bridge while cellular data stays disabled.")
+            self.log(f"ModemManager SIM access failed repeatedly for {hwid}; "
+                     "falling back to direct serial")
         self.log(f"SIM bridge for {hwid} exited after {uptime:.0f}s "
                  f"(rc={proc.returncode}, attempt {count})"
                  + (f": {reason}" if reason else ""))
@@ -907,6 +917,8 @@ class Orchestrator:
             return False
         if plan["cellular_devices"]:
             return True
+        if present_ids and set(present_ids) <= set(plan.get("flight_mode_devices") or []):
+            return False
         if not plan["cellular_backend_required"]:
             return False
         if present_ids and set(present_ids) <= set(self._degraded):

--- a/tests/test_device_state.py
+++ b/tests/test_device_state.py
@@ -717,6 +717,28 @@ modem.3gpp.registration-state : unknown
             self.assertIn("keeps exiting", document["error"])
             self.assertIn("Errno 71", document["error"])
 
+    def test_repeated_modemmanager_sim_phone_failure_degrades_to_direct_serial(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            app = Orchestrator(root / "data", root, dry_run=True)
+            app.root.mkdir(parents=True)
+            app._bridge_stderr_path("a").write_text(
+                "ModemError: SIM logical channel allocation failed (0/3 allocated): "
+                "GDBus.Error:org.freedesktop.ModemManager1.Error.MobileEquipment."
+                "PhoneFailure: Phone failure\n")
+            proc = SimpleNamespace(returncode=1)
+
+            for _ in range(3):
+                app._record_bridge_exit("a", proc, time.time() - 1)
+
+            self.assertIn("a", app._degraded)
+            self.assertIn("direct serial", app._degraded["a"])
+            plan = Orchestrator.capability_plan({
+                "a": {"cellular_enabled": False, "flight_mode": True,
+                      "vowifi_enabled": True},
+            })
+            self.assertFalse(app.cellular_backend_needed(plan, {"a"}, {}))
+
     def test_a_freshly_respawned_bridge_only_counts_once_it_survives_the_settle_window(self):
         with tempfile.TemporaryDirectory() as temp:
             root = Path(temp)
@@ -800,6 +822,50 @@ modem.3gpp.registration-state : unknown
             self.assertEqual(document["shared"]["modem_backend"], "serial")
             self.assertEqual(document["shared"]["cellular_backend"],
                              "disabled-by-configuration")
+
+    def test_flight_mode_only_uses_direct_serial_without_modemmanager(self):
+        with tempfile.TemporaryDirectory() as temp:
+            app = Orchestrator(Path(temp) / "data", Path(temp), dry_run=True)
+            flight_only = Orchestrator.capability_plan({
+                "a": {"cellular_enabled": False, "flight_mode": True,
+                      "vowifi_enabled": True},
+            })
+            self.assertFalse(app.cellular_backend_needed(flight_only, {"a"}, {}))
+
+            with_cellular = Orchestrator.capability_plan({
+                "a": {"cellular_enabled": True, "flight_mode": True,
+                      "vowifi_enabled": True},
+            })
+            self.assertTrue(app.cellular_backend_needed(with_cellular, {"a"}, {}))
+
+    def test_status_labels_a_live_bridge_direct_when_modemmanager_is_stopped(self):
+        with tempfile.TemporaryDirectory() as temp:
+            app = Orchestrator(Path(temp) / "data", Path(temp), dry_run=True)
+            app.root.mkdir(parents=True)
+            app.bridges["a"] = SimpleNamespace(poll=lambda: None)
+            app._bridge_started["a"] = time.time() - 10
+            assignments = {"a": {"id": "a", "name": "A", "tty": "/dev/ttyUSB2"}}
+            with patch.object(app, "service_active", return_value=False):
+                app.publish_device_status({"a": {"vowifi_enabled": True}}, assignments)
+
+            device = device_state._read(str(app.device_status_path), {})["devices"]["a"]
+            self.assertEqual(device["actual"]["vowifi_backend"], "direct-serial")
+
+    def test_flight_mode_direct_serial_is_a_settled_device_state(self):
+        with tempfile.TemporaryDirectory() as temp:
+            app = Orchestrator(Path(temp) / "data", Path(temp), dry_run=True)
+            app.root.mkdir(parents=True)
+            app.bridges["a"] = SimpleNamespace(poll=lambda: None)
+            app._bridge_started["a"] = time.time() - 10
+            desired = {"a": {"cellular_enabled": False, "flight_mode": True,
+                              "vowifi_enabled": True}}
+            assignments = {"a": {"id": "a", "name": "A", "tty": "/dev/ttyUSB2"}}
+
+            with patch.object(app, "service_active", return_value=False):
+                app.publish_device_status(desired, assignments)
+
+            device = device_state._read(str(app.device_status_path), {})["devices"]["a"]
+            self.assertFalse(device["transitioning"])
 
     def test_standing_down_skips_the_modem_reset(self):
         with tempfile.TemporaryDirectory() as temp:


### PR DESCRIPTION
## 摘要

当 ModemManager 无法稳定访问 EC25 的 SIM 通道时，桥接进程可能连续因 PhoneFailure 退出。飞行模式或 ModemManager 已停止的场景下，实际工作的 direct-serial 桥接也可能仍被状态机显示为处理中。

本 PR：
- 连续三次出现 ModemManager PhoneFailure 逻辑通道错误后，降级到 direct-serial SIM 桥接；
- 在只请求飞行模式/VoWiFi、没有蜂窝数据需求时允许停止 ModemManager；
- 将已运行但 ModemManager 不活动的桥接标记为 direct-serial；
- 使直连串口 VoWiFi 状态稳定结束过渡，而不是永久显示处理中；
- 与 v1.3.10 新增的显式 VoWiFi-only 串口模式兼容。

## 设备环境

- 原生 Debian GNU/Linux 13（trixie），x86_64/amd64
- Quectel EC25 类 USB 蜂窝模块，USB VID:PID 2c7c:0125
- 单个 EC25 模块配合多 Profile eUICC
- ModemManager、PC/SC、VPCD 和 direct-serial 后端
- 曾观察到 PhoneFailure、logical channel allocation failed 和 device or resource busy

## 关联问题

Related to #1

## 安全与隐私影响

- [x] 未包含真实 SIM 身份、电话号码、服务器地址或代理凭据。
- [x] 仅在重复出现明确的 SIM 逻辑通道 PhoneFailure 后自动降级。
- [x] 降级后蜂窝数据保持禁用，不会静默改用其他蜂窝路径。
- [x] 用户可见变化已记录在 CHANGELOG.md。
- [x] 已增加设备状态、飞行模式和 ModemManager 失败测试。

## 验证结果

- Python 全量测试：477 项通过。
- Python 编译检查通过。
- WebUI 构建通过，96 个模块转换完成。

## 限制

该修复改善的是主机侧模块访问、串口争用和状态呈现；它不改变运营商的 IMS、VoWiFi 或短信策略。

## 参考

- #1：ModemManager 与模块认领、串口后端问题
- 上游 v1.3.10 串口模式：https://github.com/MddIdd/mdd-sim-gateway/commit/6ed8765ece1f7d0c6385c4a3a5f06510d1aa63b1
- 贡献规范：https://github.com/MddIdd/mdd-sim-gateway/blob/main/CONTRIBUTING.md