### PR TITLE
fix: preserve Issue triage failure notices

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -230,10 +230,7 @@ jobs:
 
   report-failure:
     needs: analyze
-    if: >-
-      needs.analyze.result == 'failure' &&
-      needs.analyze.outputs.attempt != '' &&
-      needs.analyze.outputs.attempt != '0'
+    if: needs.analyze.result == 'failure'
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -243,17 +240,26 @@ jobs:
         with:
           script: |
             const marker = '<!-- mdd-codex-issue-triage-failure -->';
-            const attemptMarker = '<!-- mdd-codex-issue-triage-attempt:${{ needs.analyze.outputs.attempt }} -->';
             const issueNumber = context.issue.number || Number('${{ inputs.issue_number }}');
-            const body = `${marker}\n${attemptMarker}\n## 自动分析暂时失败\n\n` +
-              'Codex 分析服务当前不可用或返回了无效结果。维护者 `MddIdd` 需要人工查看；' +
-              '本次失败不会执行代码、部署或其他仓库写入。';
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber,
               per_page: 100,
             });
+            const attempts = comments
+              .filter((comment) => comment.user?.login === 'github-actions[bot]')
+              .flatMap((comment) => {
+                const match = comment.body?.match(
+                  /<!-- mdd-codex-issue-triage-attempt:(\d+) -->/
+                );
+                return match ? [Number(match[1])] : [];
+              });
+            const attempt = Math.min(Math.max(0, ...attempts) + 1, 3);
+            const attemptMarker = `<!-- mdd-codex-issue-triage-attempt:${attempt} -->`;
+            const body = `${marker}\n${attemptMarker}\n## 自动分析暂时失败\n\n` +
+              'Codex 分析服务当前不可用或返回了无效结果。维护者 `MddIdd` 需要人工查看；' +
+              '本次失败不会执行代码、部署或其他仓库写入。';
             const existing = comments.find((comment) =>
               comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker)
             );

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ All notable changes follow Keep a Changelog and Semantic Versioning.
 
 ### Fixed
 
+- Failed Issue analyses now leave a separate bounded notice even when the failed model Job cannot
+  expose its step outputs, while preserving the last successful analysis comment.
+
 - Fixed update-scope selection so “all versions” follows the approved latest Release while
   “main versions only” can still install its independently configured stable Release by tag after
   newer patches are published. The legacy promotion field remains synchronized so gateways older

--- a/tests/test_issue_triage.py
+++ b/tests/test_issue_triage.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 
 SCRIPT = Path(__file__).parents[1] / ".github" / "scripts" / "issue_triage.py"
+WORKFLOW = Path(__file__).parents[1] / ".github" / "workflows" / "issue-triage.yml"
 SPEC = importlib.util.spec_from_file_location("issue_triage", SCRIPT)
 issue_triage = importlib.util.module_from_spec(SPEC)
 assert SPEC.loader is not None
@@ -146,6 +147,14 @@ class IssueTriageTests(unittest.TestCase):
         self.assertIn(issue_triage.MARKER, comment)
         self.assertIn(issue_triage.ATTEMPT_MARKER.format(attempt=2), comment)
         self.assertNotIn(issue_triage.FAILURE_MARKER, comment)
+
+    def test_failure_notice_does_not_depend_on_outputs_from_failed_job(self):
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        failure_job = workflow.split("\n  report-failure:\n", 1)[1]
+
+        self.assertIn("if: needs.analyze.result == 'failure'", failure_job)
+        self.assertNotIn("needs.analyze.outputs.attempt", failure_job)
+        self.assertIn("Math.max(0, ...attempts) + 1", failure_job)
 
     def test_invalid_enum_is_rejected(self):
         with self.assertRaisesRegex(ValueError, "Invalid category"):


### PR DESCRIPTION
## Summary

- run the bounded failure reporter whenever the analysis Job fails
- recompute the attempt number from trusted GitHub Actions comments instead of unavailable failed-Job outputs
- preserve the separate success and failure comment markers

## Validation

- 855 local unit tests passed
- Python, shell, subscriber-identifier, diff, privacy, and workflow YAML checks passed

## Test finding

The first live test reached the configured Responses endpoint but received `401 Invalid API key`. The repository `API_KEY` must be updated to a client key accepted by the ProxyCLI instance before retrying.