### PR TITLE
release: promote v1.7.0 update channels

### DIFF
--- a/update-policy.json
+++ b/update-policy.json
@@ -1,21 +1,21 @@
 {
   "schema": 1,
   "release": {
-    "version": "1.6.0",
+    "version": "1.7.0",
     "kind": "main"
   },
   "auto_update": {
-    "version": "1.6.0",
-    "not_before": "2026-08-29T08:54:10Z"
+    "version": "1.7.0",
+    "not_before": "2026-09-01T01:34:27Z"
   },
   "channels": {
     "all": {
-      "version": "1.6.0",
-      "not_before": "2026-08-29T08:54:10Z"
+      "version": "1.7.0",
+      "not_before": "2026-09-01T01:34:27Z"
     },
     "main": {
-      "version": "1.6.0",
-      "not_before": "2026-08-29T08:54:10Z"
+      "version": "1.7.0",
+      "not_before": "2026-09-01T01:34:27Z"
     }
   }
 }


### PR DESCRIPTION
## Summary
- promote the approved release policy to v1.7.0
- authorize both all-version and main-version channels from 2026-09-01T01:34:27Z
- keep the legacy auto-update target synchronized with the all-version channel

## Verification
- `python3 -m json.tool update-policy.json`
- `python3 -m unittest tests.test_update_check.UpdateCheckTests.test_repository_policy_keeps_legacy_and_all_channel_in_sync`
- `git diff --check`