### PR TITLE
fix(engine): answer a bare EAP-Request/Identity at IKE_AUTH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes follow Keep a Changelog and Semantic Versioning.
 
 ## [Unreleased]
 
+### Fixed
+
+- A bare RFC 3748 EAP-Request/Identity in the first IKE_AUTH reply — how Lebara UK's (PLMN 234-87)
+  self-hosted ePDG opens EAP before any EAP-AKA exchange — was not recognised, so the attach
+  aborted with a misleading NO EAP PAYLOAD RECEIVED. The engine now answers it with an
+  EAP-Response/Identity carrying the IMSI NAI and continues into EAP-AKA. When an EAP payload is
+  present but its method is still unsupported, the error now names the received code and type
+  instead of claiming no payload arrived
+  ([#43](https://github.com/MddIdd/mdd-sim-gateway/issues/43)).
+
 ## [1.8.0] - 2026-09-01
 
 ### Added

--- a/engine/swu_ike.py
+++ b/engine/swu_ike.py
@@ -492,6 +492,16 @@ def requests_permanent_eap_identity(attributes):
     )
 
 
+def build_eap_identity_response(identifier, identity):
+    """EAP-Response/Identity (RFC 3748 §5.1): the Type-Data is the bare NAI,
+    with none of EAP-AKA's attribute framing."""
+    identity_bytes = identity.encode()
+    return (bytes([EAP_RESPONSE, identifier])
+            + struct.pack('!H', 5 + len(identity_bytes))
+            + bytes([EAP_IDENTITY])
+            + identity_bytes)
+
+
 #states
 OK =                            0
 TIMEOUT =                       1
@@ -806,6 +816,7 @@ EAP_SUCCESS  = 3
 EAP_FAILURE  = 4
 
 #IANA EAP Type
+EAP_IDENTITY = 1
 EAP_AKA = 23
 
 #EAP-AKA/EAP-SIM Subtypes:
@@ -4238,6 +4249,7 @@ class swu():
             return TIMEOUT,'TIMEOUT'
 
         eap_received = False
+        eap_summary = None
         if self.ike_decoded_header['exchange_type'] == IKE_AUTH and self.decoded_payload[0][0] == SK:
             print('received IKE_AUTH (1)')             
             for i in self.decoded_payload[0][1]:
@@ -4265,7 +4277,23 @@ class swu():
                         return OTHER_ERROR,str(code)
 
                 elif i[0] == EAP:
-                    if i[1][0] in (EAP_REQUEST,) and i[1][2] in (EAP_AKA,):
+                    eap_summary = 'code=%s type=%s' % (i[1][0], i[1][2] if len(i[1]) > 2 else '-')
+                    if i[1][0] in (EAP_REQUEST,) and i[1][2] == EAP_IDENTITY:
+                        # Lebara UK's ePDG (234-87) opens with a bare RFC 3748
+                        # EAP-Request/Identity before starting EAP-AKA (issue #43);
+                        # answer with the NAI and resend, like the AKA-Identity path.
+                        self.eap_identifier = i[1][1]
+                        identity = (
+                                '0'
+                                + self.imsi
+                                + '@nai.epc.mnc' + self.mnc
+                                + '.mcc' + self.mcc
+                                + '.3gppnetwork.org'
+                        )
+                        self.eap_payload_response = build_eap_identity_response(self.eap_identifier, identity)
+                        return REPEAT_STATE,'EAP IDENTITY REQUESTED'
+
+                    elif i[1][0] in (EAP_REQUEST,) and i[1][2] in (EAP_AKA,):
                         if i[1][3] in (AKA_Challenge, AKA_Reauthentication):
                             
                             eap_received = True
@@ -4402,6 +4430,9 @@ class swu():
 
             if eap_received == True:
                 return OK,''               
+            elif eap_summary is not None:
+                # An EAP payload WAS present — we just don't handle this method.
+                return MANDATORY_INFORMATION_MISSING,'UNHANDLED EAP PAYLOAD (%s)' % eap_summary
             else:
                 return MANDATORY_INFORMATION_MISSING,'NO EAP PAYLOAD RECEIVED'              
             

--- a/tests/test_eap_identity_request.py
+++ b/tests/test_eap_identity_request.py
@@ -1,0 +1,69 @@
+"""Bare EAP-Request/Identity handling (Lebara UK 234-87 opens EAP with it, issue #43)."""
+import ast
+import struct
+import unittest
+from pathlib import Path
+
+
+SOURCE = Path(__file__).resolve().parent.parent / "engine" / "swu_ike.py"
+WANTED = {"build_eap_identity_response"}
+
+
+def _load():
+    tree = ast.parse(SOURCE.read_text(encoding="utf-8"))
+    wanted_constants = {"EAP_REQUEST", "EAP_RESPONSE", "EAP_IDENTITY", "EAP_AKA"}
+    assignments = [
+        node for node in tree.body
+        if isinstance(node, ast.Assign)
+        and any(isinstance(target, ast.Name) and target.id in wanted_constants
+                for target in node.targets)
+    ]
+    functions = [
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in WANTED
+    ]
+    names = {"struct": struct}
+    exec(compile(ast.Module(body=assignments + functions, type_ignores=[]), str(SOURCE), "exec"), names)  # noqa: S102
+    return {name: names[name] for name in WANTED}, names, tree
+
+
+FUNCTIONS, CONSTANTS, TREE = _load()
+NAI = "0234870000000000@nai.epc.mnc087.mcc234.3gppnetwork.org"
+
+
+class EapIdentityResponseTests(unittest.TestCase):
+    def test_response_layout_matches_rfc3748(self):
+        payload = FUNCTIONS["build_eap_identity_response"](7, NAI)
+        self.assertEqual(payload[0], CONSTANTS["EAP_RESPONSE"])
+        self.assertEqual(payload[1], 7)
+        self.assertEqual(struct.unpack("!H", payload[2:4])[0], len(payload))
+        self.assertEqual(payload[4], CONSTANTS["EAP_IDENTITY"])
+
+    def test_type_data_is_the_bare_nai_without_attribute_framing(self):
+        payload = FUNCTIONS["build_eap_identity_response"](7, NAI)
+        self.assertEqual(payload[5:], NAI.encode())
+        self.assertEqual(len(payload), 5 + len(NAI))
+
+    def test_identifier_is_echoed_across_its_full_range(self):
+        for identifier in (0, 1, 255):
+            payload = FUNCTIONS["build_eap_identity_response"](identifier, NAI)
+            self.assertEqual(payload[1], identifier)
+
+
+class State2WiringTests(unittest.TestCase):
+    def test_state_2_answers_a_bare_identity_request(self):
+        state_2 = next(
+            node for cls in TREE.body if isinstance(cls, ast.ClassDef)
+            for node in cls.body
+            if isinstance(node, ast.FunctionDef) and node.name == "state_2"
+        )
+        calls = {
+            call.func.id
+            for call in ast.walk(state_2)
+            if isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
+        }
+        self.assertIn("build_eap_identity_response", calls)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes the engine-side half of #43.

Lebara UK's (PLMN 234-87) self-hosted ePDG opens EAP with a **bare RFC 3748 EAP-Request/Identity (EAP type 1)** in the IKE_AUTH(1) reply, before any EAP-AKA payload. `state_2` only recognised EAP-AKA (type 23), so the payload fell through every branch and the attach aborted with a misleading `NO EAP PAYLOAD RECEIVED`.

This is the same failure *symptom* the DITO work in #35 fixed, but a different cause: #35 covered identity-request attribute variants *inside* EAP-AKA (`AT_PERMANENT_ID_REQ`/`AT_FULLAUTH_ID_REQ`), while the plain Identity request is a different EAP method entirely and was still unhandled in v1.8.0.

## Changes

- Add `EAP_IDENTITY = 1` and a module-level `build_eap_identity_response(identifier, identity)` — an EAP-Response/Identity whose Type-Data is the bare IMSI NAI (`0<IMSI>@nai.epc.mnc<MNC>.mcc<MCC>.3gppnetwork.org`), with none of EAP-AKA's attribute framing.
- In `state_2`, answer a bare `EAP-Request/Identity` through the existing `REPEAT_STATE` → `create_IKE_AUTH_EAP_IDENTITY()` resend path. This mirrors the flow the reporter's patched build already proved out on-air (identity answered → AKA-Challenge received → SIM auth completed).
- When an EAP payload is present but its method is still unsupported, report `UNHANDLED EAP PAYLOAD (code=… type=…)` instead of falsely claiming no payload arrived.
- Regression tests for the response layout (RFC 3748 §5.1) and for the `state_2` wiring, following the AST-extraction pattern of `test_dito_vowifi_compat.py`.

The behaviour is not PLMN-gated: answering a standard EAP Identity request is universally correct, and only triggers when the peer actually sends one.

## Testing

- `python3 -m unittest tests.test_eap_identity_request tests.test_dito_vowifi_compat` — 9 tests pass.
- Full local suite: 709 tests pass; the 17 errors are pre-existing `ModuleNotFoundError`s for deps not installed on this machine (fastapi/jinja2/docker/panoramisk), unrelated to this change.

Note (per the issue thread): with this fix the attach will progress into EAP-AKA against Lebara, but the reporter's on-air trace shows their AAA then rejects with `PLMN_NOT_ALLOWED (11011)` — that half is carrier-side entitlement and is being followed up in #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)