### PR TITLE
fix(keepalive): allow intervals up to 365 days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes follow Keep a Changelog and Semantic Versioning.
   instead of claiming no payload arrived
   ([#43](https://github.com/MddIdd/mdd-sim-gateway/issues/43)).
 
+- Number-keeping intervals can now be configured for up to 365 days instead of being capped at
+  90 days, covering carriers with 180-day retention policies
+  ([#40](https://github.com/MddIdd/mdd-sim-gateway/issues/40)).
+
 ## [1.8.0] - 2026-09-01
 
 ### Added

--- a/control/app/main.py
+++ b/control/app/main.py
@@ -5289,6 +5289,7 @@ async def api_allowance_query(iid: str, body: dict):
 
 # ----------------------------- Number keeping -----------------------------
 KEEPALIVE_ACTIONS = {"sms", "balance_watch"}
+KEEPALIVE_MAX_INTERVAL_DAYS = 365
 
 
 def _local_tz() -> ZoneInfo:
@@ -5341,8 +5342,9 @@ def _clean_keepalive(body: dict) -> dict:
         interval = 30 if raw_interval in (None, "") else int(raw_interval)
     except (TypeError, ValueError):
         raise HTTPException(422, "interval_days must be a number") from None
-    if not 1 <= interval <= 90:
-        raise HTTPException(422, "interval_days must be between 1 and 90")
+    if not 1 <= interval <= KEEPALIVE_MAX_INTERVAL_DAYS:
+        raise HTTPException(
+            422, f"interval_days must be between 1 and {KEEPALIVE_MAX_INTERVAL_DAYS}")
     enabled = 1 if body.get("enabled") else 0
     sms_to = str(body.get("sms_to") or "").strip()
     sms_body = str(body.get("sms_body") or "").strip()

--- a/tests/test_keepalive.py
+++ b/tests/test_keepalive.py
@@ -125,6 +125,18 @@ class KeepaliveConfigApiTests(unittest.TestCase):
         self.assertEqual(
             self._save({"enabled": True, "action": "balance_watch"})["interval_days"], 30)
 
+    def test_long_carrier_keepalive_intervals_are_accepted_and_bounded(self):
+        # Some carriers keep a prepaid number alive for 180 days. Leave room for annual
+        # policies as well, while retaining a finite API guard against nonsensical values.
+        for value in (180, main.KEEPALIVE_MAX_INTERVAL_DAYS):
+            record = self._save({"enabled": True, "action": "balance_watch",
+                                 "interval_days": value})
+            self.assertEqual(record["interval_days"], value)
+        with self.assertRaises(Exception) as caught:
+            self._save({"enabled": True, "action": "balance_watch",
+                        "interval_days": main.KEEPALIVE_MAX_INTERVAL_DAYS + 1})
+        self.assertEqual(getattr(caught.exception, "status_code", None), 422)
+
     def test_watching_a_balance_needs_no_recipient(self):
         record = self._save({"enabled": True, "action": "balance_watch", "threshold": "10"})
         self.assertEqual(record["action"], "balance_watch")

--- a/webui/src/views/Keepalive.jsx
+++ b/webui/src/views/Keepalive.jsx
@@ -9,6 +9,7 @@ import AllowancePanel from './AllowancePanel.jsx'
 // lives on the device page and is deliberately not repeated here.
 
 const DAY = 86400
+const KEEPALIVE_MAX_INTERVAL_DAYS = 365
 
 const fmtDate = (ts) => (ts ? new Date(ts * 1000).toLocaleDateString() : '—')
 const fmtDateTime = (ts) => (ts ? new Date(ts * 1000).toLocaleString() : '—')
@@ -95,7 +96,7 @@ function KeepaliveForm({ line, onSaved, showToast }) {
     <div className="u-form-grid" style={{ marginTop: 10 }}>
       <div>
         <label>{t('Then every (days)')}</label>
-        <input type="number" min="1" max="90" value={draft.interval_days}
+        <input type="number" min="1" max={KEEPALIVE_MAX_INTERVAL_DAYS} value={draft.interval_days}
           onChange={e => set({ interval_days: Number(e.target.value) })} />
       </div>
       <div />


### PR DESCRIPTION
## Summary

- raise the number-keeping interval limit from 90 to 365 days
- keep the Web UI and API validation aligned
- cover 180-day and 365-day policies with API tests
- document the change in the changelog

## Validation

- python -m unittest tests.test_keepalive.KeepaliveConfigApiTests (13 passed)
- npm run build with an isolated output directory
- git diff --check

Fixes #40