### PR TITLE
chore(release): register v1.8.1 without automatic promotion

### DIFF
--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -226,11 +226,18 @@ class UpdateCheckTests(unittest.TestCase):
         policy = __import__("json").loads(
             (Path(__file__).resolve().parents[1] / "update-policy.json").read_text())
         self.assertEqual(policy["auto_update"], policy["channels"]["all"])
+        all_version = policy["channels"]["all"]["version"]
         self.assertEqual(
             update_check._policy_target(
-                policy, "all", policy["release"]["version"]),
-            policy["channels"]["all"]["version"],
+                policy, "all", all_version),
+            all_version,
         )
+        if policy["release"]["version"] != all_version:
+            self.assertEqual(
+                update_check._policy_target(
+                    policy, "all", policy["release"]["version"]),
+                "",
+            )
         self.assertEqual(
             update_check._policy_target(
                 policy, "main", policy["release"]["version"]),

--- a/update-policy.json
+++ b/update-policy.json
@@ -1,8 +1,8 @@
 {
   "schema": 1,
   "release": {
-    "version": "1.8.0",
-    "kind": "main"
+    "version": "1.8.1",
+    "kind": "patch"
   },
   "auto_update": {
     "version": "1.8.0",


### PR DESCRIPTION
## Summary

- register the published `v1.8.1` release as a patch release
- intentionally retain `channels.all`, `channels.main`, and the legacy `auto_update` compatibility target at hardware-validated `v1.8.0`
- make the checked-in policy test support and verify the documented staged state where the latest Release has not yet been promoted

## Why channels remain on v1.8.0

The release checklist requires ARM64 and amd64 real-device acceptance before changing automatic installation channels. CI, release assets, checksums, and the GHCR multi-architecture manifest have passed, but no real-device acceptance evidence is available in this session. This PR records the release without claiming that acceptance or exposing it to unattended updates.

## Validation

- `python3 -m json.tool update-policy.json`
- `python3 -m unittest tests.test_update_check` — **37 passed**
- `git diff --check`
