### PR TITLE
feat(update): show five recent stable releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes follow Keep a Changelog and Semantic Versioning.
 - Renaming a running SIM line now updates its display metadata without rebuilding the line's
   IKE and Asterisk engine; edits to operational settings continue to restart the line so they are
   actually applied ([#53](https://github.com/MddIdd/mdd-sim-gateway/issues/53)).
+- The manual update selector now offers the five most recent stable releases instead of only the
+  latest one, making recent rollback or version switching available from System Settings.
 
 ## [1.8.1] - 2026-09-02
 

--- a/control/app/update_check.py
+++ b/control/app/update_check.py
@@ -25,6 +25,7 @@ _stars_cache: int | None = None
 _stars_checked_at = 0.0
 _STARS_CACHE_SECONDS = 15 * 60
 _MAX_RELEASE_NOTES_CHARS = 16_000
+_MANUAL_STABLE_RELEASE_LIMIT = 5
 # How long a "running" progress document may go unrefreshed before it stops counting as proof
 # that an update is alive. The orchestrator retires abandoned runs within a minute by asking
 # systemd whether the updater unit still exists; these are the control plane's own fallback for
@@ -310,9 +311,9 @@ def _release_result(payload: dict, selection: dict, repository_name: str,
 def releases(force: bool = False) -> dict:
     """List manually selectable Releases.
 
-    The latest stable Release is the normal channel target. Published GitHub prereleases are
-    exposed as test versions; drafts are never returned. Older stable releases are deliberately
-    omitted so this remains a channel switch rather than a general-purpose downgrade browser.
+    The five latest stable Releases are normal-version choices. Published GitHub prereleases are
+    exposed as test versions; drafts are never returned. Limiting the stable history keeps this
+    useful for recent rollback without turning it into a general-purpose downgrade browser.
     """
     global _releases_cache
     now = time.time()
@@ -335,7 +336,7 @@ def releases(force: bool = False) -> dict:
             payload = response.json()
             if not isinstance(payload, list):
                 raise ValueError("GitHub Releases response is not a list")
-            stable_seen = False
+            stable_count = 0
             choices = []
             for release in payload:
                 if not isinstance(release, dict) or release.get("draft"):
@@ -344,9 +345,9 @@ def releases(force: bool = False) -> dict:
                 if not re.fullmatch(r"\d+(?:\.\d+)*(?:-[0-9A-Za-z.]+)?", version):
                     continue
                 prerelease = bool(release.get("prerelease"))
-                if not prerelease and stable_seen:
+                if not prerelease and stable_count >= _MANUAL_STABLE_RELEASE_LIMIT:
                     continue
-                stable_seen = stable_seen or not prerelease
+                stable_count += int(not prerelease)
                 item = _release_result(release, selection, repository_name)
                 # Manual channel switching may move to an older stable version, so equality —
                 # not semantic ordering — decides whether there is something to install.

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -172,12 +172,16 @@ class UpdateCheckTests(unittest.TestCase):
         self.assertFalse(result["ok"])
         self.assertFalse(result["update_available"])
 
-    def test_manual_release_list_exposes_latest_stable_and_published_tests(self):
+    def test_manual_release_list_exposes_five_latest_stable_and_published_tests(self):
         payload = [
             {"tag_name": "v1.7.0-rc2", "prerelease": True, "body": "test two"},
             {"tag_name": "v1.7.0-rc1", "prerelease": True, "body": "test one"},
-            {"tag_name": "v1.6.0", "prerelease": False, "body": "stable"},
-            {"tag_name": "v1.5.0", "prerelease": False, "body": "old stable"},
+            {"tag_name": "v1.6.4", "prerelease": False, "body": "stable five"},
+            {"tag_name": "v1.6.3", "prerelease": False, "body": "stable four"},
+            {"tag_name": "v1.6.2", "prerelease": False, "body": "stable three"},
+            {"tag_name": "v1.6.1", "prerelease": False, "body": "stable two"},
+            {"tag_name": "v1.6.0", "prerelease": False, "body": "stable one"},
+            {"tag_name": "v1.5.0", "prerelease": False, "body": "too old"},
             {"tag_name": "v1.8.0-dev", "prerelease": True, "draft": True},
         ]
         with patch("control.app.update_check.requests.Session.get",
@@ -185,7 +189,8 @@ class UpdateCheckTests(unittest.TestCase):
             result = update_check.releases(True)
         self.assertTrue(result["ok"])
         self.assertEqual([item["latest"] for item in result["releases"]],
-                         ["1.7.0-rc2", "1.7.0-rc1", "1.6.0"])
+                         ["1.7.0-rc2", "1.7.0-rc1", "1.6.4", "1.6.3", "1.6.2",
+                          "1.6.1", "1.6.0"])
         self.assertTrue(result["releases"][0]["prerelease"])
         self.assertFalse(result["releases"][-1]["prerelease"])
 


### PR DESCRIPTION
## Summary

- show the five most recent stable releases in the manual update selector
- keep published prereleases available as test versions
- retain a bounded stable history for recent rollback/version switching

## Validation

- `python3 -m unittest tests.test_update_check -v`
- `python3 -m py_compile control/app/update_check.py`
- `git diff --check`
- `sh tools/check-subscriber-identifiers.sh CHANGELOG.md control/app/update_check.py tests/test_update_check.py`