### PR TITLE
chore(update): promote v1.9.0 for automatic updates

### DIFF
--- a/update-policy.json
+++ b/update-policy.json
@@ -5,17 +5,17 @@
     "kind": "main"
   },
   "auto_update": {
-    "version": "1.8.0",
-    "not_before": "2026-09-02T06:05:28Z"
+    "version": "1.9.0",
+    "not_before": "2026-09-03T16:10:38Z"
   },
   "channels": {
     "all": {
-      "version": "1.8.0",
-      "not_before": "2026-09-02T06:05:28Z"
+      "version": "1.9.0",
+      "not_before": "2026-09-03T16:10:38Z"
     },
     "main": {
-      "version": "1.8.0",
-      "not_before": "2026-09-02T06:05:28Z"
+      "version": "1.9.0",
+      "not_before": "2026-09-03T16:10:38Z"
     }
   }
 }


### PR DESCRIPTION
## Summary

- promote both the all-releases and main-release automatic update channels to v1.9.0
- keep the legacy auto_update entry synchronized with the all channel
- allow activation immediately from 2026-09-03T16:10:38Z

## Acceptance

Issue #51 was verified on physical hardware by the reporter: SCR Prime recognized the card IMSI, PIN remained disabled, VoWiFi registered successfully, and SMS send/receive worked. The v1.9.0 release artifacts and multi-architecture image were also verified after publication.

Closes #51

## Validation

- python3 -m unittest tests.test_update_check -v (37 passed)
- update policy consistency check with jq
- git diff --check
- subscriber identifier privacy scan on update-policy.json