### PR TITLE
chore: sync v1.9.0 update promotion to develop

### DIFF
--- a/update-policy.json
+++ b/update-policy.json
@@ -5,17 +5,17 @@
     "kind": "main"
   },
   "auto_update": {
-    "version": "1.8.0",
-    "not_before": "2026-09-02T06:05:28Z"
+    "version": "1.9.0",
+    "not_before": "2026-09-03T16:10:38Z"
   },
   "channels": {
     "all": {
-      "version": "1.8.0",
-      "not_before": "2026-09-02T06:05:28Z"
+      "version": "1.9.0",
+      "not_before": "2026-09-03T16:10:38Z"
     },
     "main": {
-      "version": "1.8.0",
-      "not_before": "2026-09-02T06:05:28Z"
+      "version": "1.9.0",
+      "not_before": "2026-09-03T16:10:38Z"
     }
   }
 }


### PR DESCRIPTION
## Summary

Sync the published v1.9.0 automatic-update promotion from main back into develop, keeping the integration branch aligned with the live update policy.

## Source

- promotion PR: #58
- main merge: 54e14588ce56ccdde689df669d1ddda57d4405bc
- post-merge main CI: passed