### PR TITLE
feat(vowifi): record preflight blocks and catch live ICCID mismatch (#60)

### DIFF
--- a/control/app/engine.py
+++ b/control/app/engine.py
@@ -34,6 +34,10 @@ LIFECYCLE_RECORDS = 500
 LIFECYCLE_EVENTS = {
     "recovery_scheduled", "recovery_blocked", "recovery_started", "recovery_failed",
     "recovery_succeeded", "recovery_cancelled", "vowifi_disabled",
+    # A start/reprovision refused by the PIN/identity preflight before the engine ran.
+    # reason_code carries the closed code (no_card / pin_required / pin_invalid /
+    # card_mismatch); the ICCID itself never enters this public record.
+    "preflight_blocked",
 }
 _LIFECYCLE_REASON = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
 _LIFECYCLE_INSTANCE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
@@ -319,7 +323,7 @@ def record_lifecycle(iid: str, event: str, *, reason_code: str = "", **facts) ->
     # support-safe and is exactly what distinguishes a carrier refusal from a dead tunnel.
     if facts.get("sip_status") is not None:
         record["sip_status"] = max(0, min(999, int(facts["sip_status"])))
-    for key in ("card_present", "imei_valid", "imei_source_matches"):
+    for key in ("card_present", "imei_valid", "imei_source_matches", "iccid_matches"):
         if key in facts and facts[key] is not None:
             record[key] = bool(facts[key])
     base = os.path.join(DATA_DIR, "instances", iid)

--- a/control/app/main.py
+++ b/control/app/main.py
@@ -3216,8 +3216,19 @@ def _preflight_pin_locked(inst: dict, idx: int) -> dict:
     except Exception as e:  # noqa
         log.debug("preflight probe failed: %r", e)
         return {"ok": True, "need_pin": bool(inst.get("pin"))}
+    want = (inst.get("iccid") or "").strip()
     if not probe.present:
-        return {"ok": False, "code": "no_card"}
+        # Nothing readable at the reader index this line binds to. Carry the expected ICCID
+        # so the operator-facing error can say which SIM we were looking for (support bundles
+        # get only the closed reason code, never the identifier).
+        return {"ok": False, "code": "no_card", "line_iccid": want}
+    # Real-time identity check. _card_identity_mismatch runs first but off the (sampled) card
+    # monitor cache; inside an eSIM REFRESH/profile-switch window that cache lags, so a live
+    # read here is what actually catches "the reader now holds a different profile" instead of
+    # letting it fall through to a misleading no_card.
+    got = (probe.iccid or "").strip()
+    if want and got and got != want:
+        return {"ok": False, "code": "card_mismatch", "card_iccid": got, "line_iccid": want}
     if probe.pin_enabled is False:
         return {"ok": True, "need_pin": False}
     saved = inst.get("pin")
@@ -3272,10 +3283,12 @@ def _pin_preflight_http(pf: dict) -> HTTPException:
     it the toast degrades to the bare HTTP status text ("Conflict")."""
     tries = pf.get("tries")
     left = f" ({tries} tries left)" if tries is not None else ""
+    want = (pf.get("line_iccid") or "").strip()
+    expect = f" (this line expects ICCID {want})" if want else ""
     messages = {
-        "no_card": ("no readable SIM for this line — the reader is empty or it "
-                    "currently holds a different card/eSIM profile; for an eSIM, "
-                    "switch the active profile to this line's first"),
+        "no_card": ("no readable SIM at this line's reader — it is empty or the card is "
+                    "not ready yet (an eSIM resets briefly while switching profiles); if "
+                    f"you switched the eSIM, activate this line's profile first{expect}"),
         "pin_required": ("the SIM asks for a PIN and none is saved — enter the "
                          f"SIM PIN to start this line{left}"),
         "pin_invalid": f"the saved SIM PIN was rejected{left} — re-enter the PIN",
@@ -3284,6 +3297,28 @@ def _pin_preflight_http(pf: dict) -> HTTPException:
         "code": pf["code"], "tries": tries,
         "message": messages.get(pf["code"], f"SIM preflight failed: {pf['code']}"),
     })
+
+
+def _raise_preflight_block(iid: str, pf: dict):
+    """Record a closed-schema lifecycle event for the refused start (so support bundles
+    show the preflight decision without any identifier) and raise the operator-facing 409.
+
+    A live ICCID conflict is reported as the existing card_mismatch error — same shape the
+    cache-based guard produces — so the UI's message is identical however it was detected."""
+    code = pf.get("code") or ""
+    facts: dict = {}
+    if code in {"pin_required", "pin_invalid", "card_mismatch"}:
+        facts["card_present"] = True
+    elif code == "no_card":
+        facts["card_present"] = False
+    if code == "card_mismatch":
+        facts["iccid_matches"] = False
+    _record_lifecycle(str(iid), "preflight_blocked", reason_code=code, **facts)
+    if code == "card_mismatch":
+        _raise_card_mismatch({"iccid": pf.get("line_iccid") or ""},
+                             {"reader": pf.get("reader") or "the reader",
+                              "iccid": pf.get("card_iccid") or ""})
+    raise _pin_preflight_http(pf)
 
 
 @app.post("/api/provision")
@@ -4826,7 +4861,7 @@ async def api_instance_start(iid: str, body: dict | None = None):
     if not pf["ok"]:
         if pf.get("clear"):
             cfg.clear_pin(str(iid))     # stale saved PIN — force re-entry next time
-        raise _pin_preflight_http(pf)
+        _raise_preflight_block(str(iid), pf)
 
     settings = cfg.get_settings()
     dev = os.environ.get("MDD_DEV_MOUNTS", "") == "1"
@@ -4879,7 +4914,7 @@ async def api_reprovision(iid: str, body: dict | None = None):
     if not pf["ok"]:
         if pf.get("clear"):
             cfg.clear_pin(str(iid))
-        raise _pin_preflight_http(pf)
+        _raise_preflight_block(str(iid), pf)
     hub._msisdn_tries.pop(str(iid), None)
     hub.reset_health(iid, "user_requested")
     await hub.drop_ami(iid)      # engine.start recreates the container (maybe new IP) -> stale client

--- a/tests/test_pin_preflight_message.py
+++ b/tests/test_pin_preflight_message.py
@@ -4,7 +4,11 @@ Issue #60: without it the WebUI's generic error path falls back to the bare HTTP
 status text and the operator only sees "能力切换失败: Conflict" with no way to know
 the line needs a PIN (or that the reader holds another card/eSIM profile).
 """
+import json
 import unittest
+from unittest.mock import patch
+
+from fastapi import HTTPException
 
 from control.app import main
 
@@ -29,3 +33,45 @@ class PinPreflightMessageTests(unittest.TestCase):
     def test_unknown_code_still_readable(self):
         exc = main._pin_preflight_http({"ok": False, "code": "mystery"})
         self.assertIn("mystery", exc.detail["message"])
+
+    def test_no_card_carries_expected_iccid(self):
+        exc = main._pin_preflight_http({"ok": False, "code": "no_card",
+                                        "line_iccid": "8944000000000000001"})
+        self.assertIn("8944000000000000001", exc.detail["message"])
+
+
+class PreflightBlockLifecycleTests(unittest.TestCase):
+    def _capture(self, pf):
+        events = []
+        with patch.object(main, "_record_lifecycle",
+                          side_effect=lambda iid, event, **kw: events.append((event, kw))):
+            with self.assertRaises(HTTPException) as ctx:
+                main._raise_preflight_block("3", pf)
+        return events, ctx.exception
+
+    def test_records_closed_event_without_identifier(self):
+        events, exc = self._capture({"ok": False, "code": "no_card",
+                                     "line_iccid": "8944000000000000001"})
+        self.assertEqual(len(events), 1)
+        event, kw = events[0]
+        self.assertEqual(event, "preflight_blocked")
+        self.assertEqual(kw["reason_code"], "no_card")
+        self.assertIs(kw["card_present"], False)
+        # The identifier must never enter the (public) lifecycle record.
+        self.assertNotIn("8944000000000000001", json.dumps(kw))
+        self.assertEqual(exc.status_code, 409)
+        self.assertEqual(exc.detail["code"], "no_card")
+
+    def test_card_mismatch_maps_to_mismatch_error(self):
+        events, exc = self._capture({"ok": False, "code": "card_mismatch",
+                                     "card_iccid": "8944000000000000002",
+                                     "line_iccid": "8944000000000000001",
+                                     "reader": "Alcor 00 00"})
+        event, kw = events[0]
+        self.assertEqual(kw["reason_code"], "card_mismatch")
+        self.assertIs(kw["iccid_matches"], False)
+        self.assertNotIn("8944000000000000002", json.dumps(kw))
+        # Operator-facing error keeps the identifiers so the mismatch is actionable.
+        self.assertEqual(exc.detail["code"], "card_mismatch")
+        self.assertIn("8944000000000000002", exc.detail["message"])
+        self.assertIn("8944000000000000001", exc.detail["message"])


### PR DESCRIPTION
## Summary

Follow-up to the #60 fix (#61). Two diagnostics improvements for the SIM preflight that guards VoWiFi line starts.

### 1. Preflight refusals now show up in support bundles

The preflight refusal happens in the control plane *before* any engine log exists, so a support bundle previously carried no trace of it — you could only guess which line was blocked and why. A new closed-schema lifecycle event `preflight_blocked` is now written to the line's `lifecycle.jsonl` (which the bundle already collects), carrying `reason_code` (`no_card` / `pin_required` / `pin_invalid` / `card_mismatch`) plus `card_present` / `iccid_matches` booleans.

**No identifier ever enters this public record** — it stays inside the closed lifecycle schema by construction (verified by a test that asserts the ICCID is absent from the recorded fields).

### 2. Live ICCID compare fixes a misleading `no_card`

`_card_identity_mismatch` runs first but reads the *sampled* card-monitor cache. Inside an eSIM REFRESH / profile-switch window that cache lags, so a profile switch fell through and the preflight reported a vague `no_card`. The preflight now compares the **live-read ICCID** against the line's expected ICCID and reports the existing `card_mismatch` error instead (with both ICCIDs — operator-facing only, same surface that already prints ICCIDs). A genuine `no_card` now names the line's expected ICCID so the operator knows which SIM was sought.

## Privacy

ICCID is a subscriber identifier. It appears only in the operator-facing 409 (the `card_mismatch` message already did this pre-existing). It is kept out of the public support bundle / lifecycle record entirely.

## Test plan

- `python -m unittest discover -s tests` — 1028 tests pass (3 new)
- verified the closed-schema writer persists `preflight_blocked` + `iccid_matches` and rejects a malformed reason code
- `npm run build` in webui — builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)