### PR TITLE
fix(sim): a card that answers 61xx has accepted the SELECT (#60)

### DIFF
--- a/control/app/engine.py
+++ b/control/app/engine.py
@@ -36,7 +36,7 @@ LIFECYCLE_EVENTS = {
     "recovery_succeeded", "recovery_cancelled", "vowifi_disabled",
     # A start/reprovision refused by the PIN/identity preflight before the engine ran.
     # reason_code carries the closed code (no_card / pin_required / pin_invalid /
-    # card_mismatch); the ICCID itself never enters this public record.
+    # card_mismatch / card_unreadable); the ICCID itself never enters this public record.
     "preflight_blocked",
 }
 _LIFECYCLE_REASON = re.compile(r"^[a-z][a-z0-9_]{0,63}$")

--- a/control/app/main.py
+++ b/control/app/main.py
@@ -3229,6 +3229,13 @@ def _preflight_pin_locked(inst: dict, idx: int) -> dict:
     got = (probe.iccid or "").strip()
     if want and got and got != want:
         return {"ok": False, "code": "card_mismatch", "card_iccid": got, "line_iccid": want}
+    if probe.pin_enabled is None:
+        # The card answered, but read_card never got far enough to learn its PIN state (an
+        # ADF.USIM select that failed leaves every PIN field unset). Falling through would
+        # report 'pin_required' with an unknown retry counter, and the UI would ask for a PIN
+        # that cannot help — the dead end issues #51 and #60 both ended in. Report the read
+        # failure itself so the operator sees a fixable fact.
+        return {"ok": False, "code": "card_unreadable", "error": probe.error or ""}
     if probe.pin_enabled is False:
         return {"ok": True, "need_pin": False}
     saved = inst.get("pin")
@@ -3248,6 +3255,7 @@ async def _preflight_pin(inst: dict) -> dict:
     """Actively check the SIM's PIN state BEFORE starting the engine (so we never spin up
     the SWu tunnel/IMS against a locked card). Reads the physical card:
       - card absent                         -> {ok:False, code:'no_card'}
+      - card present but unreadable         -> {ok:False, code:'card_unreadable'}
       - PIN not required (disabled)          -> {ok:True,  need_pin:False}
       - PIN required, no saved PIN           -> {ok:False, code:'pin_required'}
       - PIN required, saved PIN verifies     -> {ok:True,  need_pin:True}
@@ -3285,6 +3293,8 @@ def _pin_preflight_http(pf: dict) -> HTTPException:
     left = f" ({tries} tries left)" if tries is not None else ""
     want = (pf.get("line_iccid") or "").strip()
     expect = f" (this line expects ICCID {want})" if want else ""
+    detail = str(pf.get("error") or "").strip()
+    because = f" ({detail})" if detail else ""
     messages = {
         "no_card": ("no readable SIM at this line's reader — it is empty or the card is "
                     "not ready yet (an eSIM resets briefly while switching profiles); if "
@@ -3292,6 +3302,9 @@ def _pin_preflight_http(pf: dict) -> HTTPException:
         "pin_required": ("the SIM asks for a PIN and none is saved — enter the "
                          f"SIM PIN to start this line{left}"),
         "pin_invalid": f"the saved SIM PIN was rejected{left} — re-enter the PIN",
+        "card_unreadable": ("the SIM was detected but could not be read"
+                            f"{because} — this is not a PIN problem, so entering one will "
+                            "not help; reseat the card and report this error if it persists"),
     }
     return HTTPException(409, {
         "code": pf["code"], "tries": tries,
@@ -3307,7 +3320,7 @@ def _raise_preflight_block(iid: str, pf: dict):
     cache-based guard produces — so the UI's message is identical however it was detected."""
     code = pf.get("code") or ""
     facts: dict = {}
-    if code in {"pin_required", "pin_invalid", "card_mismatch"}:
+    if code in {"pin_required", "pin_invalid", "card_mismatch", "card_unreadable"}:
         facts["card_present"] = True
     elif code == "no_card":
         facts["card_present"] = False

--- a/control/app/sim.py
+++ b/control/app/sim.py
@@ -93,19 +93,46 @@ def _hx(s: str):
     return [int(s[i:i + 2], 16) for i in range(0, len(s), 2)]
 
 
+def _apdu_with_le(apdu, le):
+    """Rebuild an APDU carrying the Le the card asked for in a 6Cxx status. Case 2 replaces
+    the trailing Le byte; case 3/4 keeps Lc and the command data and re-stamps only Le.
+    Truncating to CLA/INS/P1/P2 (what the first version did) turned a case-4 SELECT into a
+    malformed command, so the retry failed and a healthy file read as unselectable."""
+    head = list(apdu[:4])
+    if len(apdu) <= 5:
+        return head + [le]
+    lc = apdu[4]
+    return head + [lc] + list(apdu[5:5 + lc]) + [le]
+
+
 def _xfr(conn, apdu: list[int]):
     """Transmit one APDU, normalizing reader/protocol variance (issue #51). TPDU-level
     T=0 readers answer case-4 commands with 61xx and expect an explicit GET RESPONSE;
     APDU-level readers and T=1 hand back the data with 9000 directly. 6Cxx means
-    "wrong Le, retry with mine". Callers see one shape: (data, 0x90, 0x00) on success."""
+    "wrong Le, retry with mine". Callers see one shape: (data, 0x90, 0x00) on success.
+
+    61xx already means the card ACCEPTED the command -- the GET RESPONSE that follows only
+    fetches the body. Reporting that fetch's status as the command's status made a good
+    SELECT ADF.USIM read as a card fault on cards whose GET RESPONSE answers anything but
+    9000, which is issue #60: read_card bailed out with no PIN state at all and the start
+    preflight then asked for a PIN the card never wanted. Callers that need the body check
+    the body they got, so answering "accepted, here is what we could fetch" is safe."""
     data, sw1, sw2 = conn.transmit(apdu)
     data = list(data)
-    while sw1 == 0x61:
-        more, sw1, sw2 = conn.transmit([0x00, 0xC0, 0x00, 0x00, sw2])
-        data += list(more)
-    if sw1 == 0x6C and sw2:
-        data, sw1, sw2 = conn.transmit(list(apdu[:4]) + [sw2])
-        data = list(data)
+    accepted = False
+    for _ in range(8):      # bound: a card that keeps re-asking cannot spin us forever
+        if sw1 == 0x61:
+            accepted = True
+            more, sw1, sw2 = conn.transmit([0x00, 0xC0, 0x00, 0x00, sw2])
+            data += list(more)
+            continue
+        if sw1 == 0x6C and sw2 and not accepted:
+            data, sw1, sw2 = conn.transmit(_apdu_with_le(apdu, sw2))
+            data = list(data)
+            continue
+        break
+    if accepted and sw1 != 0x90:
+        return data, 0x90, 0x00
     return data, sw1, sw2
 
 

--- a/engine/ami_usim.py
+++ b/engine/ami_usim.py
@@ -179,19 +179,46 @@ def dec_imsi(ef):
     return imsi
 
 
+def _apdu_with_le(apdu, le):
+    """Rebuild an APDU carrying the Le the card asked for in a 6Cxx status. Case 2 replaces
+    the trailing Le byte; case 3/4 keeps Lc and the command data and re-stamps only Le.
+    Truncating to CLA/INS/P1/P2 (what the first version did) turned a case-4 SELECT into a
+    malformed command, so the retry failed and a healthy file read as unselectable."""
+    head = list(apdu[:4])
+    if len(apdu) <= 5:
+        return head + [le]
+    lc = apdu[4]
+    return head + [lc] + list(apdu[5:5 + lc]) + [le]
+
+
 def _xfr(connection, apdu):
     """Transmit one APDU, normalizing reader/protocol variance (issue #51). TPDU-level
     T=0 readers answer case-4 commands with 61xx and expect an explicit GET RESPONSE;
     APDU-level readers and T=1 hand back the data with 9000 directly. 6Cxx means
-    "wrong Le, retry with mine". Callers see one shape: (data, 0x90, 0x00) on success."""
+    "wrong Le, retry with mine". Callers see one shape: (data, 0x90, 0x00) on success.
+
+    61xx already means the card ACCEPTED the command -- the GET RESPONSE that follows only
+    fetches the body. Reporting that fetch's status as the command's status made a good
+    SELECT ADF.USIM read as a card fault on cards whose GET RESPONSE answers anything but
+    9000, which is issue #60: read_card bailed out with no PIN state at all and the start
+    preflight then asked for a PIN the card never wanted. Callers that need the body check
+    the body they got, so answering "accepted, here is what we could fetch" is safe."""
     data, sw1, sw2 = connection.transmit(apdu)
     data = list(data)
-    while sw1 == 0x61:
-        more, sw1, sw2 = connection.transmit([0x00, 0xC0, 0x00, 0x00, sw2])
-        data += list(more)
-    if sw1 == 0x6C and sw2:
-        data, sw1, sw2 = connection.transmit(list(apdu[:4]) + [sw2])
-        data = list(data)
+    accepted = False
+    for _ in range(8):      # bound: a card that keeps re-asking cannot spin us forever
+        if sw1 == 0x61:
+            accepted = True
+            more, sw1, sw2 = connection.transmit([0x00, 0xC0, 0x00, 0x00, sw2])
+            data += list(more)
+            continue
+        if sw1 == 0x6C and sw2 and not accepted:
+            data, sw1, sw2 = connection.transmit(_apdu_with_le(apdu, sw2))
+            data = list(data)
+            continue
+        break
+    if accepted and sw1 != 0x90:
+        return data, 0x90, 0x00
     return data, sw1, sw2
 
 

--- a/engine/pin_keeper.py
+++ b/engine/pin_keeper.py
@@ -95,19 +95,46 @@ def swap_nibbles(s):
     return "".join([x + y for x, y in zip(s[1::2], s[0::2])])
 
 
+def _apdu_with_le(apdu, le):
+    """Rebuild an APDU carrying the Le the card asked for in a 6Cxx status. Case 2 replaces
+    the trailing Le byte; case 3/4 keeps Lc and the command data and re-stamps only Le.
+    Truncating to CLA/INS/P1/P2 (what the first version did) turned a case-4 SELECT into a
+    malformed command, so the retry failed and a healthy file read as unselectable."""
+    head = list(apdu[:4])
+    if len(apdu) <= 5:
+        return head + [le]
+    lc = apdu[4]
+    return head + [lc] + list(apdu[5:5 + lc]) + [le]
+
+
 def _xfr(conn, apdu):
     """Transmit one APDU, normalizing reader/protocol variance (issue #51). TPDU-level
     T=0 readers answer case-4 commands with 61xx and expect an explicit GET RESPONSE;
     APDU-level readers and T=1 hand back the data with 9000 directly. 6Cxx means
-    "wrong Le, retry with mine". Callers see one shape: (data, 0x90, 0x00) on success."""
+    "wrong Le, retry with mine". Callers see one shape: (data, 0x90, 0x00) on success.
+
+    61xx already means the card ACCEPTED the command -- the GET RESPONSE that follows only
+    fetches the body. Reporting that fetch's status as the command's status made a good
+    SELECT ADF.USIM read as a card fault on cards whose GET RESPONSE answers anything but
+    9000, which is issue #60: read_card bailed out with no PIN state at all and the start
+    preflight then asked for a PIN the card never wanted. Callers that need the body check
+    the body they got, so answering "accepted, here is what we could fetch" is safe."""
     data, s1, s2 = conn.transmit(apdu)
     data = list(data)
-    while s1 == 0x61:
-        more, s1, s2 = conn.transmit([0x00, 0xC0, 0x00, 0x00, s2])
-        data += list(more)
-    if s1 == 0x6C and s2:
-        data, s1, s2 = conn.transmit(list(apdu[:4]) + [s2])
-        data = list(data)
+    accepted = False
+    for _ in range(8):      # bound: a card that keeps re-asking cannot spin us forever
+        if s1 == 0x61:
+            accepted = True
+            more, s1, s2 = conn.transmit([0x00, 0xC0, 0x00, 0x00, s2])
+            data += list(more)
+            continue
+        if s1 == 0x6C and s2 and not accepted:
+            data, s1, s2 = conn.transmit(_apdu_with_le(apdu, s2))
+            data = list(data)
+            continue
+        break
+    if accepted and s1 != 0x90:
+        return data, 0x90, 0x00
     return data, s1, s2
 
 

--- a/engine/swu_ike.py
+++ b/engine/swu_ike.py
@@ -6205,19 +6205,46 @@ def read_res_ck_ik_2(reader_index,rand,autn):
 _USIM_AID_PREFIX = "A0000000871002"
 
 
+def _swu_apdu_with_le(apdu, le):
+    """Rebuild an APDU carrying the Le the card asked for in a 6Cxx status. Case 2 replaces
+    the trailing Le byte; case 3/4 keeps Lc and the command data and re-stamps only Le.
+    Truncating to CLA/INS/P1/P2 (what the first version did) turned a case-4 SELECT into a
+    malformed command, so the retry failed and a healthy file read as unselectable."""
+    head = list(apdu[:4])
+    if len(apdu) <= 5:
+        return head + [le]
+    lc = apdu[4]
+    return head + [lc] + list(apdu[5:5 + lc]) + [le]
+
+
 def _swu_xfr(conn, apdu):
     """Transmit one APDU, normalizing reader/protocol variance (issue #51). TPDU-level
     T=0 readers answer case-4 commands with 61xx and expect an explicit GET RESPONSE;
     APDU-level readers and T=1 hand back the data with 9000 directly. 6Cxx means
-    "wrong Le, retry with mine". Callers see one shape: (data, 0x90, 0x00) on success."""
+    "wrong Le, retry with mine". Callers see one shape: (data, 0x90, 0x00) on success.
+
+    61xx already means the card ACCEPTED the command -- the GET RESPONSE that follows only
+    fetches the body. Reporting that fetch's status as the command's status made a good
+    SELECT ADF.USIM read as a card fault on cards whose GET RESPONSE answers anything but
+    9000, which is issue #60: read_card bailed out with no PIN state at all and the start
+    preflight then asked for a PIN the card never wanted. Callers that need the body check
+    the body they got, so answering "accepted, here is what we could fetch" is safe."""
     data, s1, s2 = conn.transmit(apdu)
     data = list(data)
-    while s1 == 0x61:
-        more, s1, s2 = conn.transmit([0x00, 0xC0, 0x00, 0x00, s2])
-        data += list(more)
-    if s1 == 0x6C and s2:
-        data, s1, s2 = conn.transmit(list(apdu[:4]) + [s2])
-        data = list(data)
+    accepted = False
+    for _ in range(8):      # bound: a card that keeps re-asking cannot spin us forever
+        if s1 == 0x61:
+            accepted = True
+            more, s1, s2 = conn.transmit([0x00, 0xC0, 0x00, 0x00, s2])
+            data += list(more)
+            continue
+        if s1 == 0x6C and s2 and not accepted:
+            data, s1, s2 = conn.transmit(_swu_apdu_with_le(apdu, s2))
+            data = list(data)
+            continue
+        break
+    if accepted and s1 != 0x90:
+        return data, 0x90, 0x00
     return data, s1, s2
 
 

--- a/tests/test_pin_preflight_message.py
+++ b/tests/test_pin_preflight_message.py
@@ -17,7 +17,8 @@ class PinPreflightMessageTests(unittest.TestCase):
     def test_every_code_carries_message(self):
         for pf in ({"ok": False, "code": "no_card"},
                    {"ok": False, "code": "pin_required", "tries": 3},
-                   {"ok": False, "code": "pin_invalid", "clear": True, "tries": 2}):
+                   {"ok": False, "code": "pin_invalid", "clear": True, "tries": 2},
+                   {"ok": False, "code": "card_unreadable", "error": "ADF.USIM select failed"}):
             exc = main._pin_preflight_http(pf)
             self.assertEqual(exc.status_code, 409)
             self.assertEqual(exc.detail["code"], pf["code"])
@@ -33,6 +34,20 @@ class PinPreflightMessageTests(unittest.TestCase):
     def test_unknown_code_still_readable(self):
         exc = main._pin_preflight_http({"ok": False, "code": "mystery"})
         self.assertIn("mystery", exc.detail["message"])
+
+    def test_card_unreadable_names_the_read_failure_and_rules_out_a_pin(self):
+        """Issue #60: an unreadable card used to fall through to 'pin_required' with an
+        unknown retry counter, so the UI asked for a PIN that could not help. The message
+        must carry the real read error and say a PIN is not the answer."""
+        exc = main._pin_preflight_http({"ok": False, "code": "card_unreadable",
+                                        "error": "ADF.USIM select failed"})
+        self.assertIn("ADF.USIM select failed", exc.detail["message"])
+        self.assertIn("not a PIN problem", exc.detail["message"])
+
+    def test_card_unreadable_without_a_detail_still_reads(self):
+        exc = main._pin_preflight_http({"ok": False, "code": "card_unreadable"})
+        self.assertTrue(exc.detail["message"])
+        self.assertNotIn("()", exc.detail["message"])
 
     def test_no_card_carries_expected_iccid(self):
         exc = main._pin_preflight_http({"ok": False, "code": "no_card",
@@ -61,6 +76,14 @@ class PreflightBlockLifecycleTests(unittest.TestCase):
         self.assertNotIn("8944000000000000001", json.dumps(kw))
         self.assertEqual(exc.status_code, 409)
         self.assertEqual(exc.detail["code"], "no_card")
+
+    def test_card_unreadable_records_a_present_card(self):
+        events, exc = self._capture({"ok": False, "code": "card_unreadable",
+                                     "error": "ADF.USIM select failed"})
+        event, kw = events[0]
+        self.assertEqual(kw["reason_code"], "card_unreadable")
+        self.assertIs(kw["card_present"], True)
+        self.assertEqual(exc.detail["code"], "card_unreadable")
 
     def test_card_mismatch_maps_to_mismatch_error(self):
         events, exc = self._capture({"ok": False, "code": "card_mismatch",

--- a/tests/test_reader_apdu_compat.py
+++ b/tests/test_reader_apdu_compat.py
@@ -49,40 +49,50 @@ class FakeUsim:
                    reader or T=1 card, the shape issue #51's reader produces.
     """
 
-    def __init__(self, mode, pin_enabled=False):
+    def __init__(self, mode, pin_enabled=False, broken_get_response=()):
         assert mode in ("tpdu", "direct")
         self.mode = mode
         self.pin_enabled = pin_enabled
+        # Files whose 61xx the card raises but whose GET RESPONSE it then refuses. Issue #60:
+        # 61xx already means "command accepted", so a refused body fetch must not be read as
+        # a failed SELECT.
+        self.broken_get_response = set(broken_get_response)
         self.verified = False
         self.selected = None
         self.pending = None
+        self.pending_from = None
         self.log = []
 
     # -- response shaping ------------------------------------------------------
-    def _case4(self, data):
+    def _case4(self, data, origin=None):
         if self.mode == "direct":
             return list(data), 0x90, 0x00
         self.pending = list(data)
+        self.pending_from = origin
         return [], 0x61, len(data)
 
     def transmit(self, apdu):
         self.log.append(bytes(apdu).hex())
         ins, p1 = apdu[1], apdu[2]
         if ins == 0xC0:  # GET RESPONSE
+            origin, self.pending_from = self.pending_from, None
+            if origin in self.broken_get_response:
+                self.pending = None
+                return [], 0x6F, 0x00
             data, self.pending = self.pending or [], None
             return data, 0x90, 0x00
         if ins == 0xA4:  # SELECT
             body = bytes(apdu[5:5 + apdu[4]]).hex().upper() if len(apdu) > 5 else ""
             if p1 == 0x04 and body == USIM_AID:
                 self.selected = "adf"
-                return self._case4(sim._hx("62058A0105FFFF"))
+                return self._case4(sim._hx("62058A0105FFFF"), "adf")
             if body == "2F00":
                 self.selected = "dir"
                 # FCP: 62 06 82 04 42 21 00 26 -> record length fcp[7] = 0x26
-                return self._case4(sim._hx("6206820442210026"))
+                return self._case4(sim._hx("6206820442210026"), "dir")
             if body in ("3F00", "6F07"):
                 self.selected = body
-                return self._case4(sim._hx("62058A0105FFFF"))
+                return self._case4(sim._hx("62058A0105FFFF"), body)
             self.selected = None
             return [], 0x6A, 0x82  # file not found (EF_AD/SPN/GID/SMSP not scripted)
         if ins == 0xB2 and self.selected == "dir":  # READ RECORD in EF_DIR
@@ -126,8 +136,9 @@ class FakeReader:
 
 
 class ReaderShapeTests(unittest.TestCase):
-    def _read(self, mode, pin_enabled=False, pin=None):
-        card = FakeUsim(mode, pin_enabled=pin_enabled)
+    def _read(self, mode, pin_enabled=False, pin=None, broken_get_response=()):
+        card = FakeUsim(mode, pin_enabled=pin_enabled,
+                        broken_get_response=broken_get_response)
         old = sim.readers
         sim.readers = lambda: [FakeReader(card)]
         try:
@@ -159,6 +170,16 @@ class ReaderShapeTests(unittest.TestCase):
         info, card = self._read("direct", pin_enabled=True, pin=PIN)
         self.assertTrue(card.verified)
         self.assertEqual(info.imsi, IMSI)
+
+    def test_select_survives_a_refused_get_response(self):
+        """Issue #60 regression: v1.9.0 read SELECT ADF.USIM's success off the GET RESPONSE
+        that follows it, so a card that raises 61xx (accepted) but refuses to hand the FCP
+        back read as "ADF.USIM select failed" — read_card returned with every PIN field
+        unset and the start preflight asked for a PIN the card does not even use."""
+        info, _ = self._read("tpdu", broken_get_response={"adf"})
+        self.assertEqual(info.imsi, IMSI)
+        self.assertIs(info.pin_enabled, False)
+        self.assertIsNone(info.error)
 
     def test_verify_pin_on_direct_reader(self):
         card = FakeUsim("direct", pin_enabled=True)
@@ -202,6 +223,46 @@ class XfrTests(unittest.TestCase):
         data, s1, s2 = sim._xfr(Conn(), sim._hx("00b0000009"))
         self.assertEqual(seen[1], [0x00, 0xB0, 0x00, 0x00, 0x0A])
         self.assertEqual((len(data), s1), (10, 0x90))
+
+    def test_6c_retry_keeps_the_command_body(self):
+        """A case-4 SELECT retried on 6Cxx must keep Lc and the file id. Truncating to
+        CLA/INS/P1/P2 re-sent "00A40004 <Le>", a malformed command the card can only
+        reject, which surfaced as an unselectable file (issue #60)."""
+        seen = []
+
+        class Conn:
+            def transmit(self, apdu):
+                seen.append(list(apdu))
+                if len(seen) == 1:
+                    return [], 0x6C, 0x07
+                return list(range(7)), 0x90, 0x00
+
+        data, s1, s2 = sim._xfr(Conn(), sim._hx("00a40004022f0000"))
+        self.assertEqual(seen[1], sim._hx("00a40004022f00") + [0x07])
+        self.assertEqual((len(data), s1, s2), (7, 0x90, 0x00))
+
+    def test_61_is_success_even_when_get_response_is_refused(self):
+        """61xx is the card accepting the command; the GET RESPONSE only fetches the body.
+        Callers that need the body validate it, so a refused fetch must not be reported as
+        a failed command (issue #60)."""
+        class Conn:
+            def __init__(self):
+                self.calls = 0
+
+            def transmit(self, apdu):
+                self.calls += 1
+                return ([], 0x61, 0x1F) if self.calls == 1 else ([], 0x6F, 0x00)
+
+        data, s1, s2 = sim._xfr(Conn(), sim._hx("00a40404") + [4] + sim._hx("A0000000"))
+        self.assertEqual((data, s1, s2), ([], 0x90, 0x00))
+
+    def test_apdu_with_le_shapes(self):
+        self.assertEqual(sim._apdu_with_le(sim._hx("00b0000009"), 0x0A),
+                         sim._hx("00b000000a"))                       # case 2: replace Le
+        self.assertEqual(sim._apdu_with_le(sim._hx("00a40004022f0000"), 0x07),
+                         sim._hx("00a40004022f0007"))                 # case 4: keep Lc+data
+        self.assertEqual(sim._apdu_with_le(sim._hx("00a4040402ff01"), 0x12),
+                         sim._hx("00a4040402ff0112"))                 # case 3: append Le
 
 
 class ValidationTests(unittest.TestCase):


### PR DESCRIPTION
Fixes the card-read regression reported in #60: on v1.9.0 the reporter's SIMs read as PIN-locked ("这张 SIM 卡需要 PIN 码（剩余？次尝试）") even though none of them has a PIN, and enabling VoWiFi was refused; v1.8.1 works.

## What broke

`0d7b01e` (issue #51, APDU-level readers) routed every SELECT/READ through `_xfr()` and moved each success check from `SW1 == 0x61` to `SW1 == 0x90`. That made the verdict on a SELECT come from the **GET RESPONSE that follows it** rather than from the SELECT itself. On a card whose GET RESPONSE answers anything but `9000`, `SELECT ADF.USIM` then reads as a failure and:

1. `read_card` returns early at `ADF.USIM select failed`, leaving `pin_enabled`/`pin_tries` unset;
2. `_preflight_pin_locked` sees `pin_enabled=None`, falls through to `pin_required` with `tries=None`;
3. the UI pops "This SIM requires a PIN (**?** tries left)" — the `? tries` fingerprint, same as #51.

v1.8.1 was unaffected because it read the SELECT's own `61xx`.

## Fix

- **`_xfr` reports the command's own verdict.** `61xx` means the card *accepted* the command; the GET RESPONSE only fetches the body. A refused fetch now returns `(what we got, 0x90, 0x00)` instead of the fetch's status — callers that need the body already validate it (`len(fcp) < 8`, etc.). This *widens* the accepted shapes rather than swapping one reader class for another, so #51's APDU-level/T=1 support stays.
- **`_apdu_with_le()`** fixes the `6Cxx` retry, which rebuilt the command as `CLA/INS/P1/P2 + Le` and dropped `Lc` + data — retrying a case-4 SELECT sent a malformed command that could only fail.
- The GET RESPONSE chain is **bounded** (8 steps) so a card that keeps re-asking cannot spin a worker forever.
- Applied identically in `control/app/sim.py`, `engine/pin_keeper.py`, `engine/ami_usim.py`, `engine/swu_ike.py`.
- **Preflight stops guessing**: when `read_card` could not learn the PIN state it now returns `card_unreadable` carrying the real read error, so the operator sees *"the SIM was detected but could not be read (ADF.USIM select failed) — this is not a PIN problem"* instead of an unanswerable PIN prompt.

## Tests

`tests/test_reader_apdu_compat.py` — the fake USIM can now refuse GET RESPONSE per file:

- `test_select_survives_a_refused_get_response` — the #60 regression; **fails on `develop`**, passes here.
- `test_6c_retry_keeps_the_command_body`, `test_61_is_success_even_when_get_response_is_refused`, `test_apdu_with_le_shapes`.

`tests/test_pin_preflight_message.py` — `card_unreadable` carries the read error, says a PIN will not help, and records `card_present=True` without an identifier.

Full suite: 1035 passed.

## Not yet proven on the reporter's hardware

The exact APDU the reporter's card stalls on can only be confirmed with a trace from their reader. What is certain from the evidence: the failure is inside `_select_adf_usim` (the `? tries` fingerprint is only reachable via that early return), it is new in v1.9.0, and `0d7b01e` is the only commit between v1.8.1 and v1.9.0 that touches this path. The fix restores v1.8.1's acceptance of `61xx` while keeping v1.9.0's, so it covers the failure whichever of the two SELECTs in that path is the one refusing.

Separately, the v1.9.0 auto-update promotion is being rolled back on `main` so no gateway installs this unattended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)