### PR TITLE
chore(update): roll the auto-update channels back off v1.9.0

### DIFF
--- a/update-policy.json
+++ b/update-policy.json
@@ -5,17 +5,17 @@
     "kind": "main"
   },
   "auto_update": {
-    "version": "1.9.0",
-    "not_before": "2026-09-03T16:10:38Z"
+    "version": "1.8.0",
+    "not_before": "2026-09-02T06:05:28Z"
   },
   "channels": {
     "all": {
-      "version": "1.9.0",
-      "not_before": "2026-09-03T16:10:38Z"
+      "version": "1.8.0",
+      "not_before": "2026-09-02T06:05:28Z"
     },
     "main": {
-      "version": "1.9.0",
-      "not_before": "2026-09-03T16:10:38Z"
+      "version": "1.8.0",
+      "not_before": "2026-09-02T06:05:28Z"
     }
   }
 }


### PR DESCRIPTION
Gateways read `update-policy.json` from `main`, so this has to land on `main` to take effect.

v1.9.0 carries a card-read regression (#60, fix in #64): `SELECT ADF.USIM` is judged by the GET RESPONSE that follows it, so on some readers a healthy PIN-free SIM reads as PIN-locked and VoWiFi will not start. Until the fix is released, no gateway should install v1.9.0 unattended.

**What changes:** both cohorts (`all`, `main`) return to the v1.8.0 target they were on before `ba53789`, with the original `not_before`. Neither channel now names GitHub's latest Release, so `auto_update_authorization` refuses both.

**What does not change:**
- There is no downgrade path and none is wanted — gateways already on v1.9.0 stay there; rolling back is a manual `git checkout v1.8.1 && install.sh reload`.
- `release` still says v1.9.0/main, which is true: it IS the latest Release, and the notify path reads availability from GitHub regardless of this file.

`test_repository_policy_keeps_legacy_and_all_channel_in_sync` already covers this staged state (release version ≠ channel version) and passes.

Re-promote once #64 ships and is validated on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)