### PR TITLE
chore: sync the v1.9.0 auto-update rollback into develop

### DIFF
--- a/update-policy.json
+++ b/update-policy.json
@@ -5,17 +5,17 @@
     "kind": "main"
   },
   "auto_update": {
-    "version": "1.9.0",
-    "not_before": "2026-09-03T16:10:38Z"
+    "version": "1.8.0",
+    "not_before": "2026-09-02T06:05:28Z"
   },
   "channels": {
     "all": {
-      "version": "1.9.0",
-      "not_before": "2026-09-03T16:10:38Z"
+      "version": "1.8.0",
+      "not_before": "2026-09-02T06:05:28Z"
     },
     "main": {
-      "version": "1.9.0",
-      "not_before": "2026-09-03T16:10:38Z"
+      "version": "1.8.0",
+      "not_before": "2026-09-02T06:05:28Z"
     }
   }
 }


### PR DESCRIPTION
Brings #65 (merged to `main`) into `develop` so `update-policy.json` is byte-identical on both branches.

Without this, the next `develop` → `main` promotion would carry develop's stale `1.9.0` channel values forward and silently re-promote the release we just pulled back.

No code changes — only `update-policy.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)