### PR TITLE
fix(sim): only a fully read EF.ICCID may convict a reader

### DIFF
--- a/control/app/sim.py
+++ b/control/app/sim.py
@@ -167,8 +167,19 @@ def dec_imsi(ef_hex: str) -> Optional[str]:
     return imsi
 
 
+ICCID_BYTES = 10
+ICCID_MIN_DIGITS = 15
+
+
 def dec_iccid(ef_hex: str) -> str:
-    return swap_nibbles(ef_hex).rstrip("f")
+    """Decode EF.ICCID (10 BCD bytes, TS 31.102). "" for anything that is not a plausible
+    ICCID: the start preflight convicts a reader whose live ICCID differs from the line's, so
+    a truncated or garbled read must not present itself as an identity. Empty simply means we
+    could not identify the card, which every caller already treats as "do not convict"."""
+    if len(ef_hex) != ICCID_BYTES * 2:
+        return ""
+    iccid = swap_nibbles(ef_hex).rstrip("f")
+    return iccid if iccid.isdigit() and len(iccid) >= ICCID_MIN_DIGITS else ""
 
 
 # 3GPP USIM application AID prefix (RID A000000087 + app code 1002). EF_DIR record 1 is

--- a/engine/ami_usim.py
+++ b/engine/ami_usim.py
@@ -157,6 +157,10 @@ def write_status(**kw):
     os.replace(tmp, os.path.join(RUNDIR, "usim_status.json"))
 
 
+ICCID_BYTES = 10
+ICCID_MIN_DIGITS = 15
+
+
 def swap_nibbles(s):
     return "".join([x + y for x, y in zip(s[1::2], s[0::2])])
 
@@ -319,13 +323,21 @@ def _with_deadline(fn, timeout=None):
 
 
 def read_iccid(connection):
-    """Read EF.ICCID (no PIN required). Returns None when the card will not answer."""
+    """Read EF.ICCID (no PIN required). None when the card will not answer readably.
+
+    EF.ICCID is exactly 10 BCD bytes (TS 31.102). A short read, or a value that is not
+    all digits, is a card or reader fault rather than an identity -- and every caller
+    convicts a reader on ANY non-empty ICCID that differs from the line's, so handing one
+    a truncated value would strand a line whose binding is perfectly correct. Returning
+    None keeps the documented fail-open direction: we simply cannot convict.
+    """
     connection.transmit(toBytes("00a40004023f0000"))
     connection.transmit(toBytes("00a40004022fe200"))
     data, sw1, sw2 = connection.transmit(toBytes("00b000000a"))
-    if sw1 != 0x90:
+    if sw1 != 0x90 or len(data) != ICCID_BYTES:
         return None
-    return swap_nibbles(bytes(data).hex()).rstrip("f")
+    iccid = swap_nibbles(bytes(data).hex()).rstrip("f")
+    return iccid if iccid.isdigit() and len(iccid) >= ICCID_MIN_DIGITS else None
 
 
 def foreign_iccid(connection):

--- a/engine/pin_keeper.py
+++ b/engine/pin_keeper.py
@@ -91,6 +91,10 @@ def write_status(state, tries_left=None, reader=None, detail=None, iccid=None):
     log(f"status={state} tries_left={tries_left} detail={detail}")
 
 
+ICCID_BYTES = 10
+ICCID_MIN_DIGITS = 15
+
+
 def swap_nibbles(s):
     return "".join([x + y for x, y in zip(s[1::2], s[0::2])])
 
@@ -272,13 +276,21 @@ def _with_deadline(fn, timeout=None):
 
 
 def read_iccid(conn):
+    """Read EF.ICCID (no PIN required). None when the card will not answer readably.
+
+    EF.ICCID is exactly 10 BCD bytes (TS 31.102). A short read, or a value that is not
+    all digits, is a card or reader fault rather than an identity -- and every caller
+    convicts a reader on ANY non-empty ICCID that differs from the line's, so handing one
+    a truncated value would strand a line whose binding is perfectly correct. Returning
+    None keeps the documented fail-open direction: we simply cannot convict.
+    """
     conn.transmit(toBytes("00a40004023f0000"))
     _xfr(conn, toBytes("00a40004022fe200"))
     d, s1, s2 = _xfr(conn, toBytes("00b000000a"))
-    if s1 != 0x90:
+    if s1 != 0x90 or len(d) != ICCID_BYTES:
         return None
-    hx = bytes(d).hex()
-    return swap_nibbles(hx).rstrip("f")
+    iccid = swap_nibbles(bytes(d).hex()).rstrip("f")
+    return iccid if iccid.isdigit() and len(iccid) >= ICCID_MIN_DIGITS else None
 
 
 class WrongCard(Exception):

--- a/engine/swu_ike.py
+++ b/engine/swu_ike.py
@@ -6098,8 +6098,19 @@ def _with_deadline(fn, timeout=None):
     return box.get("value")
 
 
+_ICCID_BYTES = 10
+_ICCID_MIN_DIGITS = 15
+
+
 def read_iccid_at_index(reader_index):
-    """Read EF.ICCID from a reader index. No PIN needed; None when the card will not answer."""
+    """Read EF.ICCID from a reader index. No PIN needed; None when it will not answer readably.
+
+    EF.ICCID is exactly 10 BCD bytes (TS 31.102). A short read, or a value that is not
+    all digits, is a card or reader fault rather than an identity -- and every caller
+    convicts a reader on ANY non-empty ICCID that differs from the line's, so handing one
+    a truncated value would strand a line whose binding is perfectly correct. Returning
+    None keeps the documented fail-open direction: we simply cannot convict.
+    """
     r = readers()
     connection = r[int(reader_index)].createConnection()
     connection.connect()
@@ -6107,9 +6118,10 @@ def read_iccid_at_index(reader_index):
         connection.transmit(toBytes('00A40000023F00'))
         connection.transmit(toBytes('00A40000022FE2'))
         data, sw1, sw2 = connection.transmit(toBytes('00B000000A'))
-        if sw1 != 0x90:
+        if sw1 != 0x90 or len(data) != _ICCID_BYTES:
             return None
-        return bcd(toHexString(data).replace(" ", "")).rstrip("Ff")
+        iccid = bcd(toHexString(data).replace(" ", "")).rstrip("Ff")
+        return iccid if iccid.isdigit() and len(iccid) >= _ICCID_MIN_DIGITS else None
     finally:
         try:
             connection.disconnect()

--- a/tests/test_iccid_probe_timeout.py
+++ b/tests/test_iccid_probe_timeout.py
@@ -39,10 +39,13 @@ def _iccid_apdu_bytes(iccid):
 class _Connection:
     """A card connection. `hangs` models the VPCD channel that never answers."""
 
-    def __init__(self, name, iccid=None, hangs=False):
+    def __init__(self, name, iccid=None, hangs=False, short_read=None):
         self.name = name
         self.iccid = iccid
         self.hangs = hangs
+        # Bytes to hand back for EF.ICCID instead of all 10 — a partial read, which decodes
+        # into a shorter number that is NOT the card's identity.
+        self.short_read = short_read
         self.disconnected = False
         self.transmits = 0
         self.released = threading.Event()
@@ -63,7 +66,10 @@ class _Connection:
         if self.iccid is None:
             raise RuntimeError("card does not answer")
         if str(apdu).lower().startswith("00b0"):
-            return _iccid_apdu_bytes(self.iccid), 0x90, 0x00
+            body = _iccid_apdu_bytes(self.iccid)
+            if self.short_read is not None:
+                body = body[:self.short_read]
+            return body, 0x90, 0x00
         return [], 0x90, 0x00
 
 
@@ -179,6 +185,21 @@ class PinKeeperProbeTests(unittest.TestCase):
         self.assertEqual(caught.exception.actual, THEIRS)
         self.assertEqual(caught.exception.expected, OURS)
         self.assertTrue(conn.disconnected)
+
+    def test_a_partial_iccid_read_does_not_convict_the_reader(self):
+        """A short EF.ICCID decodes into a number that is not the card's identity. Convicting
+        on it would strand a correctly bound line, which is exactly what _accept documents it
+        must not do: only an ICCID we actually READ can convict."""
+        conn = _Connection(PHYSICAL, iccid=OURS, short_read=6)
+        reader, got, iccid = self.mod._accept(_Reader(PHYSICAL), conn, OURS)
+        self.assertIs(got, conn)
+        self.assertIsNone(iccid, "a truncated read must not pass itself off as an identity")
+        self.assertFalse(conn.disconnected)
+
+    def test_read_iccid_rejects_a_short_or_garbled_answer(self):
+        self.assertEqual(self.mod.read_iccid(_Connection(PHYSICAL, iccid=OURS)), OURS)
+        self.assertIsNone(self.mod.read_iccid(_Connection(PHYSICAL, iccid=OURS, short_read=9)))
+        self.assertIsNone(self.mod.read_iccid(_Connection(PHYSICAL, iccid=OURS, short_read=0)))
 
 
 class AmiUsimProbeTests(unittest.TestCase):

--- a/tests/test_reader_apdu_compat.py
+++ b/tests/test_reader_apdu_compat.py
@@ -274,6 +274,16 @@ class ValidationTests(unittest.TestCase):
         self.assertIsNone(sim.dec_imsi("62058A0105FFFF"))  # an FCP misread as EF data
         self.assertIsNone(sim.dec_imsi(""))
 
+    def test_dec_iccid_rejects_short_or_garbled_reads(self):
+        """The start preflight convicts a reader whose live ICCID differs from the line's, so
+        a truncated or non-numeric EF.ICCID must decode to "" rather than to a wrong number."""
+        iccid = "8900010000000000013"                  # 19 digits, F-padded to 10 bytes
+        on_card = sim.swap_nibbles(iccid + "f")
+        self.assertEqual(sim.dec_iccid(on_card), iccid)
+        self.assertEqual(sim.dec_iccid(on_card[:12]), "")   # short read -> not an identity
+        self.assertEqual(sim.dec_iccid("ff" * 10), "")      # unprogrammed EF
+        self.assertEqual(sim.dec_iccid(""), "")
+
     def test_pin_body_validation(self):
         self.assertEqual(len(sim._pin_body("1234")), 8)
         self.assertIsNone(sim._pin_body("123"))        # too short


### PR DESCRIPTION
Found while reviewing #64 before deciding whether to promote v1.9.1 to the auto-update channels.

## The defect

`read_iccid` returned `swap_nibbles(...).rstrip("f")` on any `9000`, with no check that all 10 BCD bytes arrived or that the result is numeric. Every caller convicts a reader on **any** non-empty ICCID that differs from the line's:

```python
if not actual or actual == expected:
    return reader, conn, actual
raise WrongCard(str(reader), expected, actual)      # engine/pin_keeper.py
```

So a short or garbled read decodes into a plausible-looking number that is not the card's identity, and the line is refused as "reader holds another line's SIM". That is precisely what `_accept`'s own docstring says must not happen:

> Only an ICCID we actually READ can convict a reader. An unreadable EF.ICCID is a transient card or reader fault, not evidence of a swap; failing closed on it would strand a line whose binding is perfectly correct.

## The fix

EF.ICCID is exactly 10 BCD bytes (TS 31.102). A read returning fewer bytes, or one that does not decode to digits, is a fault and not an identity. All four copies now reject it:

| file | returns |
|---|---|
| `engine/pin_keeper.py` `read_iccid` | `None` |
| `engine/ami_usim.py` `read_iccid` | `None` |
| `engine/swu_ike.py` `read_iccid_at_index` | `None` |
| `control/app/sim.py` `dec_iccid` | `""` |

Every caller already treats empty as "cannot convict", so this is the documented fail-open direction — we lose the ability to convict on an unreadable card, which is exactly the intent.

## Scope and reachability

This gap **predates v1.9.0**: `0d7b01e` added the same class of validation to `EF_IMSI` (`dec_imsi` returns `None` for anything implausible) but left ICCID alone. It is reachable only when a card answers a case-2 READ BINARY with `61xx` and then fails the GET RESPONSE, which is why it has not been seen in the field. Closing it makes "a partial read cannot be mistaken for an identity" true by construction rather than by luck.

Not urgent enough to hold up v1.9.1; it rides in the next release.

## Tests

All three new tests fail on `develop` and pass here:

- `test_a_partial_iccid_read_does_not_convict_the_reader` — raises `WrongCard` without the fix.
- `test_read_iccid_rejects_a_short_or_garbled_answer`
- `test_dec_iccid_rejects_short_or_garbled_reads`

Full suite: 1038 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)