### PR TITLE
chore: sync the v1.9.1 auto-update promotion into develop

### DIFF
--- a/update-policy.json
+++ b/update-policy.json
@@ -5,17 +5,17 @@
     "kind": "patch"
   },
   "auto_update": {
-    "version": "1.8.0",
-    "not_before": "2026-09-02T06:05:28Z"
+    "version": "1.9.1",
+    "not_before": "2026-09-04T17:17:53Z"
   },
   "channels": {
     "all": {
-      "version": "1.8.0",
-      "not_before": "2026-09-02T06:05:28Z"
+      "version": "1.9.1",
+      "not_before": "2026-09-04T17:17:53Z"
     },
     "main": {
-      "version": "1.8.0",
-      "not_before": "2026-09-02T06:05:28Z"
+      "version": "1.9.1",
+      "not_before": "2026-09-04T17:17:53Z"
     }
   }
 }


### PR DESCRIPTION
Brings #70 into `develop` so `update-policy.json` is identical on both branches.

Without it, `develop` still carries the withdrawn `1.8.0` channel values, and the next change branched off it would undo the promotion.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)