### PR TITLE
fix: prevent recovery from disrupting healthy lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes follow Keep a Changelog and Semantic Versioning.
 
 ## [Unreleased]
 
+### Fixed
+
+- Missing tunnel evidence and local DNS, SIM, protocol or engine failures no longer count as
+  failed exit nodes. Unknown evidence does not trigger node changes or stalled-session cleanup,
+  and notifications no longer claim a clean tunnel when that has not been established.
+- Direct and non-selectable routes bypass the exit ledger instead of entering an hourly
+  candidate-exhaustion retry cycle.
+- Persisting a subscription selector's already-active node no longer restarts the shared
+  sing-box process. Actual configuration changes and process failures still trigger a restart.
+- Notification destinations run independently on a dedicated, eight-worker delivery pool;
+  HTTP retries no longer hold the default executor or serialize the configured channels.
+- Carrier identification prefers an exact PLMN, including parent-network fallback, before
+  attempting compatibility with older zero-padded two-digit MNCs.
+- VoWiFi history ignores stale request successes and failures after a newer refresh, line
+  change or unmount, and clears the previous line's error when switching lines.
+
 ## [1.9.1] - 2026-09-04
 
 ### Fixed

--- a/control/app/carrier_id.py
+++ b/control/app/carrier_id.py
@@ -161,6 +161,11 @@ def lookup(identity: dict | None) -> dict | None:
     if not plmns:
         return None
     carriers, by_id, version = _database()
+    known_plmns = {value for carrier in carriers
+                   for attribute in carrier.get("attributes") or []
+                   for value in attribute.get("mccmnc_tuple") or []}
+    selected_plmn = next((value for value in plmns if value in known_plmns), plmns[0])
+    plmns = [selected_plmn]
     best: tuple[int, int, dict, str, list[str]] | None = None
     for order, carrier in enumerate(carriers):
         for attribute in carrier.get("attributes") or []:

--- a/control/app/engine.py
+++ b/control/app/engine.py
@@ -191,7 +191,8 @@ def _charon_evidence(base: str) -> dict:
         if bare.startswith("STATE ") or "tunnel CONNECTED" in bare:
             last_state = line.strip()
             break
-    return {"retransmits": sum(1 for line in lines if "retransmit" in line),
+    return {"available": bool(lines),
+            "retransmits": sum(1 for line in lines if "retransmit" in line),
             "timeouts": sum(1 for line in lines if "TIMEOUT" in line),
             "last_state": last_state, "tail": lines[-40:]}
 

--- a/control/app/failover.py
+++ b/control/app/failover.py
@@ -23,8 +23,9 @@ The five outcomes are not symmetric, because the cost of continuing differs:
             over a transient outage trades one failure for a worse one
   GIVE_UP   stop rebuilding and report — the operator pinned this exit and it has had its
             chances, so the only useful moves left belong to a person
-  REPORT    report but keep rebuilding — the exits are fine and the fault is upstream, where
-            retrying costs nothing and the carrier may simply come back
+  REPORT    report but keep rebuilding — the evidence does not justify moving the exit;
+            report local/upstream failures or missing evidence without claiming packet loss
+            has been ruled out
 
 Stopping the churn matters as much as switching. The previous policy could not stop: once
 every candidate was cooling down it cleared the cooldown and started the pool over, forever,
@@ -67,18 +68,26 @@ GIVE_UP = "give-up"
 REPORT = "report"
 
 
-def classify(swu_state: str, retransmits: int, stable_seconds: float = 0.0,
-             stable_threshold: float = 0.0) -> str:
+def classify(swu_state: str | None, retransmits: int | None, stable_seconds: float = 0.0,
+             stable_threshold: float = 0.0, reason_code: str = "") -> str:
     """Attribute one line failure to the exit, to something else, or to neither."""
     if stable_threshold and stable_seconds >= stable_threshold:
         # The node carried a registered line for long enough to prove it can. Whatever broke
         # afterwards is not the path: a carrier-side problem, or a rekey it failed to survive.
         return BLAMES_ELSEWHERE
-    if str(swu_state or "").upper() != "CONNECTED":
-        # The tunnel never came up over this exit. That covers a path too lossy for IKE and an
-        # ePDG that refused the source address outright — both belong to the node.
+    if reason_code in {"epdg_unresolved", "tunnel_sim_auth", "tunnel_proposal",
+                       "tunnel_rekey_send_error", "client_engine_failure", "wrong_card"}:
+        return BLAMES_ELSEWHERE
+    state = str(swu_state or "").upper()
+    if retransmits is None:
+        return UNCLEAR
+    if state != "CONNECTED":
+        if state not in {"CONNECTING", "DOWN", "DISCONNECTED"}:
+            return UNCLEAR
+        if reason_code != "tunnel_network":
+            return UNCLEAR
         return BLAMES_EXIT
-    if int(retransmits or 0) >= SUSPICIOUS_RETRANSMITS:
+    if int(retransmits) >= SUSPICIOUS_RETRANSMITS:
         return UNCLEAR
     # Tunnel established and nothing went unanswered: the exit carried every packet it was
     # given. A registration that fails here failed for a reason the exit cannot explain.
@@ -114,10 +123,15 @@ def record(ledger: dict, verdict: str, node: str, pinned: bool,
         # predated backing off). Automation is allowed again: resume where the walk stopped.
         ledger["given_up"] = False
 
+    if verdict == UNCLEAR:
+        ledger["held_for_peer"] = False
+        if ledger["failures"] >= FAILURES_BEFORE_REPORT and not ledger.get("reported"):
+            ledger["reported"] = True
+            return REPORT, ledger
+        return HOLD, ledger
+
     if verdict != BLAMES_EXIT:
         if ledger.get("exhausted"):
-            # The tunnel came up: whatever kept every exit from establishing has passed, so
-            # the walk's verdicts described the outage, not the nodes. Forget them.
             ledger["exhausted"] = False
             ledger["tried"] = []
             ledger["strikes"] = 0
@@ -180,8 +194,8 @@ def summarise(ledger: dict, action: str, country: str, pinned: bool) -> str:
                     f"但同一出口正承载着 {where} 另一条注册中的线路，说明出口本身可用，为不打断"
                     "那条线路没有自动换节点。更像是运营商拒绝了这条线路从该出口接入，"
                     "请为这条线路单独指定出口或人工处理。")
-        return (f"线路已连续 {ledger.get('failures')} 次失败，但每次隧道都正常建立、链路也没有丢包，"
-                f"问题不在 {where} 出口。自动重建会继续，请检查运营商侧或 IMS 配置。")
+        return (f"线路已连续 {ledger.get('failures')} 次失败，现有证据不足以归咎于 {where} 出口，"
+                "未自动换节点。自动重建会继续，请检查本机网络、隧道日志及运营商侧或 IMS 配置。")
     if action == BACK_OFF:
         return (f"{where} 的 {tried} 个候选出口都试过了，隧道都建不起来（最后一个 {node}）。"
                 "所有节点同时失效更像是本机网络或订阅出了问题，而非节点本身；"

--- a/control/app/main.py
+++ b/control/app/main.py
@@ -1779,24 +1779,35 @@ def _judge_exit_failure(iid: str, inst: dict, st: dict, stable_for: float) -> st
         return failover.HOLD
     country = egress.line_country(inst)
     exits = (egress.status().get("exits") or {}).get(country) or {}
+    if (not cfg.get_settings().get("proxy", {}).get("enabled", False)
+            or exits.get("mode") != "subscription" or not exits.get("node")):
+        if hub.exit_ledgers.pop(iid, None) is not None:
+            _save_exit_ledgers()
+        return failover.HOLD
     node = str(exits.get("node") or "")
     candidates = [str(name) for name in (exits.get("candidates") or [])]
     pinned = exits.get("selection") == "manual"
     peer_registered = _peer_line_registered(iid, country)
+    swu, retransmits = "", None
     try:
         swu = (engine.read_run_json(iid, "swu_status.json") or {}).get("state") or ""
-        retransmits = int((engine.ike_evidence(iid) or {}).get("retransmits") or 0)
     except Exception as exc:  # noqa
         log.debug("cannot read tunnel evidence for line %s: %r", iid, exc)
-        swu, retransmits = "", 0
+    try:
+        evidence = engine.ike_evidence(iid) or {}
+        if evidence.get("available", True) and evidence.get("retransmits") is not None:
+            retransmits = int(evidence["retransmits"])
+    except Exception as exc:
+        log.debug("cannot read IKE evidence for line %s: %r", iid, exc)
     verdict = failover.classify(swu, retransmits, stable_for,
-                                egress.RESELECT_MIN_STABLE_SECONDS)
+                                egress.RESELECT_MIN_STABLE_SECONDS,
+                                reason_code=st.get("reason_code") or "unknown")
     was_backing_off = bool((hub.exit_ledgers.get(iid) or {}).get("exhausted"))
     action, ledger = failover.record(hub.exit_ledgers.get(iid), verdict, node,
                                      pinned, candidates, peer_registered=peer_registered)
     hub.exit_ledgers[iid] = ledger
     _save_exit_ledgers()
-    log.info("line %s froze (%s) after %.0fs healthy; tunnel=%s ike_retransmits=%d "
+    log.info("line %s froze (%s) after %.0fs healthy; tunnel=%s ike_retransmits=%s "
              "-> blames %s, action %s (node=%s strikes=%d tried=%d/%d peer=%s)",
              iid, st.get("reason_code"), stable_for, swu or "unknown", retransmits,
              verdict, action, node or "unknown", ledger.get("strikes") or 0,

--- a/control/app/notify_push.py
+++ b/control/app/notify_push.py
@@ -26,6 +26,8 @@ import re
 import threading
 import time
 import uuid
+from concurrent.futures import ThreadPoolExecutor
+from copy import deepcopy
 from typing import Any
 from urllib.parse import quote
 
@@ -77,6 +79,7 @@ EV_VOICEMAIL = "voicemail_received"
 EV_SOFTWARE_UPDATE = "software_update"
 
 _TIMEOUT = 8  # seconds; keep short so a dead endpoint never piles up threads
+_DELIVERY_EXECUTOR = ThreadPoolExecutor(max_workers=8, thread_name_prefix="mdd-notify")
 _TOKEN = re.compile(r"\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}")
 _HISTORY_LOCK = threading.RLock()
 _PENDING: dict[str, dict] = {}
@@ -767,38 +770,33 @@ def _post_telegram(cfg: dict, payload: dict):
 
 
 def dispatch(settings: dict, event: str, instance: dict, source: str, text: str | None = None):
-    """Fire all configured channels for one event. BLOCKING (does the HTTP itself) — the
-    caller runs this off the event path (e.g. asyncio.to_thread + create_task) so a slow
-    endpoint never stalls engine-event handling. Safe to call unconditionally: each channel
-    is gated on its own enable flag + per-event checkbox."""
+    """Queue independent deliveries on the notification pool and return their futures.
+
+    HTTP and retry waits never run on the caller's thread. Each destination is gated on its
+    own enable flag, event selection and line filter.
+    """
+    futures = []
     try:
         payload = build_payload(event, instance, source, text)
+        deliveries = []
         wh = settings.get("webhook") or {}
         if wh.get("enabled") and _events_enabled(wh).get(event):
-            _deliver_with_retry("webhook", send_webhook, wh, payload)
+            deliveries.append(("webhook", send_webhook, wh))
         tg = settings.get("telegram") or {}
         if tg.get("enabled") and _events_enabled(tg).get(event):
-            _deliver_with_retry("telegram", send_telegram, tg, payload)
+            deliveries.append(("telegram", send_telegram, tg))
         pp = settings.get("pushplus") or {}
         if pp.get("enabled") and _events_enabled(pp).get(event):
-            _deliver_with_retry("pushplus", send_pushplus, pp, payload)
-        feishu_deliveries = []
+            deliveries.append(("pushplus", send_pushplus, pp))
         for position, fs in enumerate(feishu_channels(settings.get("feishu") or {}), start=1):
             if (fs.get("enabled") and _events_enabled(fs).get(event)
                     and feishu_channel_matches(fs, payload.get("instance"))):
                 channel_id = str(fs.get("id") or position)
                 delivery_channel = "feishu" if channel_id == "legacy" else f"feishu:{channel_id}"
-                feishu_deliveries.append((delivery_channel, fs))
-        # One unavailable bot must not postpone another bot by the full 0/2/5-second retry
-        # ladder. Each destination owns an independent delivery id, retry state and thread.
-        threads = [threading.Thread(
-            target=_deliver_with_retry,
-            args=(delivery_channel, send_feishu, channel_cfg, payload),
-            daemon=True,
-        ) for delivery_channel, channel_cfg in feishu_deliveries]
-        for thread in threads:
-            thread.start()
-        for thread in threads:
-            thread.join()
+                deliveries.append((delivery_channel, send_feishu, fs))
+        for channel, sender, channel_cfg in deliveries:
+            futures.append(_DELIVERY_EXECUTOR.submit(
+                _deliver_with_retry, channel, sender, deepcopy(channel_cfg), deepcopy(payload)))
     except Exception as e:  # noqa
         log.warning("push dispatch error: %r", e)
+    return futures

--- a/host/mdd_orchestrator.py
+++ b/host/mdd_orchestrator.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import base64
 import collections
+from copy import deepcopy
 import hashlib
 import ipaddress
 import json
@@ -603,6 +604,7 @@ class Orchestrator:
         self.bridges: dict[str, subprocess.Popen] = {}
         self.bridge_ports: dict[str, int] = {}
         self.last_proxy_fingerprint = ""
+        self.last_proxy_config: dict | None = None
         self.applied_cellular_backend: bool | None = None
         self.radio_states: dict[str, bool] = {}
         self.cellular_states: dict[str, dict] = {}
@@ -2380,6 +2382,23 @@ class Orchestrator:
         fingerprint = hashlib.sha256(json.dumps(config, sort_keys=True).encode()).hexdigest()
         if fingerprint == self.last_proxy_fingerprint and self.singbox and self.singbox.poll() is None:
             return
+        if self.last_proxy_config is not None and self.singbox and self.singbox.poll() is None:
+            resumed_config = deepcopy(self.last_proxy_config)
+            selectors = {outbound.get("tag"): outbound
+                         for outbound in config.get("outbounds") or []
+                         if outbound.get("type") == "selector"}
+            for outbound in resumed_config.get("outbounds") or []:
+                tag = str(outbound.get("tag") or "")
+                current = selectors.get(tag)
+                if (outbound.get("type") == "selector" and tag.startswith("exit-")
+                        and current and current.get("default")
+                        and self.exit_resume.get(tag[len("exit-"):]) == current["default"]):
+                    outbound["default"] = current["default"]
+            if resumed_config == config:
+                atomic_json(self.generated, config)
+                self.last_proxy_fingerprint = fingerprint
+                self.last_proxy_config = deepcopy(config)
+                return
         # Restarting resets every selector to its configured default. Where that default is
         # the node already carrying this country's tunnels the restart is a no-op for the
         # exit, so the memory of it is kept and nothing is ranked: re-ranking there would
@@ -2397,6 +2416,7 @@ class Orchestrator:
         if self.dry_run:
             atomic_json(self.generated, config)
             self.last_proxy_fingerprint = fingerprint
+            self.last_proxy_config = deepcopy(config)
             return
         binary = shutil.which(os.environ.get("MDD_SINGBOX_BIN", "sing-box"))
         if not binary:
@@ -2425,6 +2445,7 @@ class Orchestrator:
                 self.singbox = None
             raise RuntimeError("sing-box exited during startup")
         self.last_proxy_fingerprint = fingerprint
+        self.last_proxy_config = deepcopy(config)
 
     def apply_xray(self, config: dict | None):
         if not config:

--- a/tests/test_carrier_id.py
+++ b/tests/test_carrier_id.py
@@ -1,9 +1,37 @@
 import unittest
+from unittest.mock import patch
 
 from control.app import carrier_id
 
 
 class CarrierIdTests(unittest.TestCase):
+    def test_exact_three_digit_mnc_wins_over_an_earlier_two_digit_record(self):
+        value = carrier_id.lookup({"mcc": "405", "mnc": "045"})
+        self.assertEqual(value["name"], "TATA DOCOMO")
+        self.assertEqual(value["plmn"], "405-045")
+
+    def test_exact_record_wins_even_when_shorter_plmn_has_more_matching_attributes(self):
+        carriers = [
+            {"carrier_name": "Short", "attributes": [
+                {"mccmnc_tuple": ["40545"], "spn": ["Test"]}]},
+            {"carrier_name": "Exact", "attributes": [{"mccmnc_tuple": ["405045"]}]},
+        ]
+        with patch.object(carrier_id, "_database", return_value=(carriers, {}, 1)):
+            value = carrier_id.lookup({"mcc": "405", "mnc": "045",
+                                       "carrier_identity": {"spn": "Test"}})
+        self.assertEqual(value["name"], "Exact")
+
+    def test_exact_parent_fallback_wins_over_an_unconditional_shorter_plmn(self):
+        carriers = [
+            {"carrier_name": "Short", "attributes": [{"mccmnc_tuple": ["40545"]}]},
+            {"carrier_name": "Exact", "attributes": [
+                {"mccmnc_tuple": ["405045"], "spn": ["Missing"]}]},
+        ]
+        with patch.object(carrier_id, "_database", return_value=(carriers, {}, 1)):
+            value = carrier_id.lookup({"mcc": "405", "mnc": "045"})
+        self.assertEqual(value["name"], "Exact")
+        self.assertEqual(value["plmn"], "405-045")
+
     def test_plain_plmn_resolves_the_home_network(self):
         value = carrier_id.lookup({"mcc": "234", "mnc": "10"})
         self.assertEqual(value["name"], "O2")

--- a/tests/test_country_egress.py
+++ b/tests/test_country_egress.py
@@ -698,6 +698,57 @@ class ManagedReselectTests(unittest.TestCase):
                 app.process_reselect_requests(states)
             self.assertEqual(app.selected, [])      # nothing measured, nothing moved
 
+    def test_persisting_a_selected_default_does_not_restart_any_country(self):
+        with tempfile.TemporaryDirectory() as temp:
+            app = self._orchestrator(temp, {})
+            config, _states = _build(app, {})
+            app.apply_singbox(config)
+            running = Mock()
+            running.poll.return_value = None
+            app.singbox = running
+            app.dry_run = False
+            started_at = app.singbox_started_at
+            app.exit_unranked.clear()
+            app.last_exit_node["us"] = "US Bravo"
+            updated, _states = _build(app, {})
+            with patch("host.mdd_orchestrator.subprocess.Popen") as spawn:
+                app.apply_singbox(updated)
+                app.apply_singbox(updated)
+            spawn.assert_not_called()
+            running.terminate.assert_not_called()
+            self.assertEqual(app.singbox_started_at, started_at)
+            self.assertEqual(app.exit_unranked, set())
+            self.assertEqual(json.loads(app.generated.read_text()), updated)
+            self.assertEqual(app.last_proxy_config, updated)
+
+    def test_real_config_changes_and_new_locks_still_restart(self):
+        for change in ("outbound", "lock", "dead_process"):
+            with self.subTest(change=change), tempfile.TemporaryDirectory() as temp:
+                app = self._orchestrator(temp, {})
+                app.last_exit_node["us"] = "US Bravo"
+                config, _states = _build(app, {})
+                app.apply_singbox(config)
+                old = Mock()
+                old.poll.return_value = 1 if change == "dead_process" else None
+                app.singbox = old
+                app.dry_run = False
+                updated, _states = _build(app, {"pinned_node": "US Alpha"}
+                                          if change == "lock" else {})
+                if change == "outbound":
+                    member = next(outbound for outbound in updated["outbounds"]
+                                  if outbound.get("tag") == "exit-us-0")
+                    member["server_port"] += 1
+                replacement = Mock()
+                replacement.poll.return_value = None
+                with patch("host.mdd_orchestrator.shutil.which", return_value="sing-box"), \
+                        patch("host.mdd_orchestrator.run", return_value=SimpleNamespace(returncode=0)), \
+                        patch("host.mdd_orchestrator.time.sleep"), \
+                        patch("host.mdd_orchestrator.subprocess.Popen", return_value=replacement) as spawn:
+                    app.apply_singbox(updated)
+                spawn.assert_called_once()
+                self.assertIs(app.singbox, replacement)
+                self.assertEqual(app.last_proxy_config, updated)
+
     def test_a_node_that_did_not_survive_the_rewrite_starts_over(self):
         with tempfile.TemporaryDirectory() as temp:
             app = self._orchestrator(temp, {"exit-us-0": 300, "exit-us-1": 800})

--- a/tests/test_failover.py
+++ b/tests/test_failover.py
@@ -9,14 +9,36 @@ class AttributionTests(unittest.TestCase):
     every one of those moved the exit, and every one of those moves was wrong."""
 
     def test_a_tunnel_that_never_came_up_blames_the_exit(self):
-        for state in ("CONNECTING", "DOWN", "", None):
+        for state in ("CONNECTING", "DOWN"):
             with self.subTest(state=state):
-                self.assertEqual(failover.classify(state, 0), failover.BLAMES_EXIT)
+                self.assertEqual(failover.classify(state, 0, reason_code="tunnel_network"),
+                                 failover.BLAMES_EXIT)
 
-    def test_an_epdg_that_refused_the_source_address_blames_the_exit(self):
-        # tunnel_not_authorized shows no packet loss at all: the ePDG answered, and refused.
-        # It is still the exit's fault — the refusal is about where the packets came from.
-        self.assertEqual(failover.classify("DOWN", 0), failover.BLAMES_EXIT)
+    def test_missing_or_unrecognized_state_is_not_exit_evidence(self):
+        for state in ("", None, "STARTING", "UNKNOWN"):
+            with self.subTest(state=state):
+                self.assertEqual(failover.classify(state, 0), failover.UNCLEAR)
+
+    def test_local_failures_do_not_blame_a_disconnected_exit(self):
+        for reason in ("epdg_unresolved", "tunnel_sim_auth", "tunnel_proposal",
+                       "tunnel_rekey_send_error", "client_engine_failure"):
+            with self.subTest(reason=reason):
+                self.assertEqual(failover.classify("DOWN", 10, reason_code=reason),
+                                 failover.BLAMES_ELSEWHERE)
+
+    def test_ambiguous_setup_or_authorization_failure_does_not_evict(self):
+        for reason in ("tunnel_setup", "tunnel_not_authorized", "unknown"):
+            self.assertEqual(failover.classify("DOWN", 0, reason_code=reason), failover.UNCLEAR)
+
+    def test_missing_retransmit_evidence_does_not_prove_a_clean_tunnel(self):
+        self.assertEqual(failover.classify("CONNECTED", None), failover.UNCLEAR)
+
+    def test_disconnected_state_alone_does_not_prove_an_exit_failure(self):
+        self.assertEqual(failover.classify("DOWN", 0), failover.UNCLEAR)
+
+    def test_unreadable_ike_evidence_does_not_strike_a_disconnected_exit(self):
+        self.assertEqual(failover.classify("DOWN", None, reason_code="tunnel_network"),
+                         failover.UNCLEAR)
 
     def test_an_established_tunnel_with_nothing_unanswered_clears_the_exit(self):
         self.assertEqual(failover.classify("CONNECTED", 0), failover.BLAMES_ELSEWHERE)
@@ -44,6 +66,23 @@ class StrikeTests(unittest.TestCase):
         action, ledger = self._strike(None, "node-a")
         self.assertEqual(action, failover.HOLD)
         self.assertEqual(ledger["strikes"], 1)
+
+    def test_unknown_evidence_preserves_the_walk_without_slowing_recovery(self):
+        ledger = {**failover.blank_ledger(), "node": "node-a", "strikes": 3,
+                  "tried": ["node-a"], "exhausted": True}
+        action, updated = self._strike(ledger, "node-a", verdict=failover.UNCLEAR)
+        self.assertEqual(action, failover.HOLD)
+        for field in ("node", "strikes", "tried", "exhausted"):
+            self.assertEqual(updated[field], ledger[field])
+
+    def test_unknown_evidence_reports_once_without_accumulating_strikes(self):
+        ledger = None
+        actions = []
+        for attempt in range(failover.FAILURES_BEFORE_REPORT + 2):
+            action, ledger = self._strike(ledger, "node-a", verdict=failover.UNCLEAR)
+            actions.append(action)
+        self.assertEqual(actions.count(failover.REPORT), 1)
+        self.assertEqual(ledger["strikes"], 0)
 
     def test_the_exit_moves_only_after_the_node_has_had_its_chances(self):
         ledger = None
@@ -220,7 +259,8 @@ class WordingTests(unittest.TestCase):
     def test_a_report_points_away_from_the_exit(self):
         ledger = {**failover.blank_ledger(), "node": "n1", "failures": 6}
         text = failover.summarise(ledger, failover.REPORT, "gb", False)
-        self.assertIn("不在 GB 出口", text)
+        self.assertIn("不足以归咎于 GB 出口", text)
+        self.assertNotIn("没有丢包", text)
         self.assertIn("会继续", text)
 
     def test_a_peer_blocked_report_names_the_line_it_protects(self):

--- a/tests/test_line_lifecycle.py
+++ b/tests/test_line_lifecycle.py
@@ -1077,25 +1077,32 @@ class ExitFailoverWiringTests(unittest.IsolatedAsyncioTestCase):
     and if giving up really stops the rebuild instead of merely saying so."""
 
     EXITS = {"exits": {"us": {"node": "node-a", "candidates": ["node-a", "node-b"],
-                              "selection": "auto"}}}
+                              "selection": "auto", "mode": "subscription"}}}
     INST = {"id": "9", "enabled": True, "mcc": "310", "mnc": "240", "name": "test"}
 
     def setUp(self):
         main.hub.exit_ledgers.pop("9", None)
         main.hub.reset_health("9")
+        settings = patch.object(main.cfg, "get_settings", return_value={"proxy": {"enabled": True}})
+        settings.start()
+        self.addCleanup(settings.stop)
+        stalled = patch.object(main.egress, "report_stalled_exit")
+        self.stalled = stalled.start()
+        self.addCleanup(stalled.stop)
 
     def tearDown(self):
         main.hub.exit_ledgers.pop("9", None)
         main.hub.reset_health("9")
 
-    def _judge(self, swu, retransmits, exits=None, stable_for=0.0, peers=()):
-        st = {"reason_code": "tunnel_network", "reason": "x"}
+    def _judge(self, swu, retransmits, exits=None, stable_for=0.0, peers=(),
+               reason="tunnel_network", evidence_error=None):
+        st = {"reason_code": reason, "reason": "x"}
         with patch.object(main.egress, "line_country", return_value="us"), \
-                patch.object(main.egress, "status", return_value=exits or self.EXITS), \
+                patch.object(main.egress, "status", return_value=self.EXITS if exits is None else exits), \
                 patch.object(main.cfg, "list_instances", return_value=list(peers)), \
                 patch.object(main.engine, "read_run_json", return_value={"state": swu}), \
                 patch.object(main.engine, "ike_evidence",
-                             return_value={"retransmits": retransmits}), \
+                             return_value={"retransmits": retransmits}, side_effect=evidence_error), \
                 patch.object(main, "_save_exit_ledgers"), \
                 patch.object(main.egress, "request_reselect") as reselect, \
                 patch.object(main.asyncio, "to_thread", new=AsyncMock()) as to_thread:
@@ -1103,6 +1110,79 @@ class ExitFailoverWiringTests(unittest.IsolatedAsyncioTestCase):
         # dispatch is handed to to_thread(), which is called synchronously to build the
         # awaitable — so its arguments are visible without waiting for the task to run.
         return action, reselect, to_thread
+
+    async def test_missing_tunnel_evidence_never_switches_or_cleans_sessions(self):
+        for attempt in range(main.failover.FAILURES_BEFORE_REPORT):
+            action, reselect, _ = self._judge(None, 0)
+            self.assertIn(action, (main.failover.HOLD, main.failover.REPORT))
+            reselect.assert_not_called()
+        self.stalled.assert_not_called()
+        self.assertEqual(main.hub.exit_ledgers["9"]["strikes"], 0)
+
+    async def test_retransmit_read_failure_preserves_connected_evidence(self):
+        for attempt in range(3):
+            action, reselect, _ = self._judge("CONNECTED", 0, evidence_error=OSError("unreadable"))
+            self.assertEqual(action, main.failover.HOLD)
+            reselect.assert_not_called()
+        self.stalled.assert_not_called()
+        self.assertEqual(main.hub.exit_ledgers["9"]["strikes"], 0)
+
+    async def test_dns_failure_never_strikes_or_cleans_an_exit(self):
+        for attempt in range(3):
+            action, reselect, _ = self._judge("DOWN", 10, reason="epdg_unresolved")
+            self.assertEqual(action, main.failover.HOLD)
+            reselect.assert_not_called()
+        self.stalled.assert_not_called()
+
+    async def test_direct_missing_and_nonselectable_exits_do_not_accumulate_ledgers(self):
+        for exits in ({}, {"exits": {}}, {"exits": {"us": {"mode": "direct"}}},
+                      {"exits": {"us": {"mode": "manual", "node": "fixed"}}}):
+            main.hub.exit_ledgers["9"] = {"exhausted": True, "given_up": True}
+            for attempt in range(4):
+                action, reselect, notify = self._judge("DOWN", 0, exits=exits)
+                self.assertEqual(action, main.failover.HOLD)
+                reselect.assert_not_called()
+                notify.assert_not_called()
+                self.assertNotIn("9", main.hub.exit_ledgers)
+        self.stalled.assert_not_called()
+
+    async def test_disabled_proxy_ignores_stale_subscription_status(self):
+        with patch.object(main.cfg, "get_settings", return_value={"proxy": {"enabled": False}}):
+            action, reselect, _ = self._judge("DOWN", 0)
+        self.assertEqual(action, main.failover.HOLD)
+        self.assertNotIn("9", main.hub.exit_ledgers)
+        reselect.assert_not_called()
+        self.stalled.assert_not_called()
+
+    async def test_direct_freezes_keep_normal_retry_cadence(self):
+        st = {"state": "TUNNEL_DOWN", "reason_code": "tunnel_network", "reason": "x"}
+        with patch.object(main.egress, "status", return_value={"exits": {"us": {"mode": "direct"}}}), \
+                patch.object(main, "_local_card_fault", return_value=""), \
+                patch.object(main, "_save_exit_ledgers"), \
+                patch.object(main.asyncio, "to_thread", new=AsyncMock()), \
+                patch.object(main.hub, "drop_ami", new=AsyncMock()):
+            for attempt in range(4):
+                main.hub.reset_health("9")
+                health = main.hub.health_for("9")
+                health["fail_start"] = main.time.monotonic() - 10000
+                before = main.time.monotonic()
+                main.apply_health("9", self.INST, dict(st))
+                self.assertGreaterEqual(health["next_retry_at"], before + 160)
+                self.assertLess(health["next_retry_at"], before + 170)
+                self.assertNotIn("9", main.hub.exit_ledgers)
+
+    def test_empty_or_missing_ike_logs_are_explicitly_unavailable(self):
+        with tempfile.TemporaryDirectory() as temp:
+            self.assertFalse(main.engine._charon_evidence(temp)["available"])
+            run = Path(temp) / "run"
+            run.mkdir()
+            log = run / "charon.log"
+            log.write_text("")
+            self.assertFalse(main.engine._charon_evidence(temp)["available"])
+            log.write_text("tunnel CONNECTED\n")
+            evidence = main.engine._charon_evidence(temp)
+            self.assertTrue(evidence["available"])
+            self.assertEqual(evidence["retransmits"], 0)
 
     async def test_a_healthy_tunnel_neither_moves_the_exit_nor_notifies(self):
         action, reselect, to_thread = self._judge("CONNECTED", 0)
@@ -1123,7 +1203,7 @@ class ExitFailoverWiringTests(unittest.IsolatedAsyncioTestCase):
         seen = []
         for node in ("node-a", "node-b"):
             exits = {"exits": {"us": {"node": node, "candidates": ["node-a", "node-b"],
-                                      "selection": "auto"}}}
+                                      "selection": "auto", "mode": "subscription"}}}
             for _ in range(main.failover.STRIKES_PER_NODE):
                 action, _reselect, to_thread = self._judge("DOWN", 0, exits)
                 seen.append((action, to_thread))

--- a/tests/test_notify_push.py
+++ b/tests/test_notify_push.py
@@ -4,6 +4,8 @@ import os
 import base64
 import hashlib
 import hmac
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from unittest.mock import MagicMock, patch
 
 import yaml
@@ -279,7 +281,8 @@ class NotificationChannelTests(unittest.TestCase):
             "url": "https://open.feishu.cn/open-apis/bot/v2/hook/test-token",
             "events": {EV_INCOMING_SMS: True},
         }}
-        notify_push.dispatch(settings, EV_INCOMING_SMS, {"id": 1}, "+100", "hello")
+        for future in notify_push.dispatch(settings, EV_INCOMING_SMS, {"id": 1}, "+100", "hello"):
+            future.result(timeout=5)
         deliver.assert_called_once()
         self.assertEqual(deliver.call_args.args[0], "feishu")
         self.assertIs(deliver.call_args.args[1], send_feishu)
@@ -294,10 +297,11 @@ class NotificationChannelTests(unittest.TestCase):
             {"id": "line-3", "enabled": True, "instances": ["3"],
              "events": {EV_INCOMING_SMS: True}},
         ]}}
-        notify_push.dispatch(settings, EV_INCOMING_SMS, {"id": "2"}, "+100", "hello")
+        for future in notify_push.dispatch(settings, EV_INCOMING_SMS, {"id": "2"}, "+100", "hello"):
+            future.result(timeout=5)
         self.assertEqual(deliver.call_count, 2)
-        self.assertEqual([call.args[0] for call in deliver.call_args_list],
-                         ["feishu:all", "feishu:line-2"])
+        self.assertCountEqual([call.args[0] for call in deliver.call_args_list],
+                              ["feishu:all", "feishu:line-2"])
 
     @patch("control.app.notify_push._deliver_with_retry")
     def test_line_filtered_feishu_channels_skip_gateway_events(self, deliver):
@@ -307,9 +311,40 @@ class NotificationChannelTests(unittest.TestCase):
             {"id": "global", "enabled": True, "instances": [],
              "events": {notify_push.EV_SOFTWARE_UPDATE: True}},
         ]}}
-        notify_push.dispatch(settings, notify_push.EV_SOFTWARE_UPDATE, {}, "1.8.0", "update")
+        for future in notify_push.dispatch(settings, notify_push.EV_SOFTWARE_UPDATE,
+                                            {}, "1.8.0", "update"):
+            future.result(timeout=5)
         deliver.assert_called_once()
         self.assertEqual(deliver.call_args.args[0], "feishu:global")
+
+    def test_slow_channels_do_not_hold_the_caller_or_delay_feishu(self):
+        release = threading.Event()
+        started = {channel: threading.Event()
+                   for channel in ("webhook", "telegram", "pushplus", "feishu")}
+        workers = []
+
+        def deliver(channel, sender, channel_cfg, payload):
+            workers.append(threading.current_thread().name)
+            started[channel].set()
+            if not release.wait(5):
+                raise TimeoutError("delivery test was not released")
+
+        settings = {channel: {"enabled": True, "events": {EV_INCOMING_SMS: True}}
+                    for channel in started}
+        with ThreadPoolExecutor(max_workers=1) as caller, \
+                patch.object(notify_push, "_deliver_with_retry", side_effect=deliver):
+            try:
+                queued = caller.submit(notify_push.dispatch, settings, EV_INCOMING_SMS,
+                                       {"id": "1"}, "+100", "hello")
+                futures = queued.result(timeout=2)
+                self.assertEqual(caller.submit(lambda: "free").result(timeout=2), "free")
+                for event in started.values():
+                    self.assertTrue(event.wait(2))
+                self.assertTrue(all(name.startswith("mdd-notify") for name in workers))
+            finally:
+                release.set()
+            for future in futures:
+                future.result(timeout=2)
 
     def test_manual_telegram_proxy_is_applied_without_environment_proxy(self):
         session = telegram_session({"proxy_mode": "manual",

--- a/tests/test_stalled_exit.py
+++ b/tests/test_stalled_exit.py
@@ -149,8 +149,8 @@ class PrincipleTests(unittest.TestCase):
     """The report must stay inside the rules that govern every exit change."""
 
     def test_the_verdict_that_triggers_it_is_the_one_that_blames_the_exit(self):
-        # A tunnel that never established is the only evidence used here.
-        self.assertEqual(failover.classify("CONNECTING", 0), failover.BLAMES_EXIT)
+        self.assertEqual(failover.classify("CONNECTING", 0, reason_code="tunnel_network"),
+                         failover.BLAMES_EXIT)
         # A tunnel that came up and carried traffic is not the exit's fault, so no report.
         self.assertEqual(failover.classify("CONNECTED", 0), failover.BLAMES_ELSEWHERE)
 

--- a/tests/test_ui_vowifi_history.py
+++ b/tests/test_ui_vowifi_history.py
@@ -1,0 +1,14 @@
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+
+class VowifiHistoryRaceTests(unittest.TestCase):
+    @unittest.skipUnless(shutil.which("node"), "Node.js is required for UI race tests")
+    def test_request_generations(self):
+        root = Path(__file__).resolve().parent.parent
+        result = subprocess.run(
+            ["node", "--test", "webui/tests/vowifi-history.test.mjs"],
+            cwd=root, capture_output=True, text=True, timeout=30)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)

--- a/tests/test_wrong_card_attribution.py
+++ b/tests/test_wrong_card_attribution.py
@@ -146,10 +146,12 @@ class ExitAttributionTests(unittest.TestCase):
                 patch.object(main, "engine", MagicMock()), \
                 patch.object(main, "_peer_line_registered", return_value=False), \
                 patch.object(main, "_save_exit_ledgers"), \
+                patch.object(main.cfg, "get_settings", return_value={"proxy": {"enabled": True}}), \
                 patch.object(main, "failover", MagicMock(
                     HOLD=failover.HOLD, SWITCH=failover.SWITCH, GIVE_UP=failover.GIVE_UP,
                     REPORT=failover.REPORT, BACK_OFF=failover.BACK_OFF)) as policy:
-            egress.status.return_value = {"exits": {}}
+            egress.line_country.return_value = "us"
+            egress.status.return_value = {"exits": {"us": {"mode": "subscription", "node": "a"}}}
             policy.record.return_value = (failover.HOLD, {})
             main._judge_exit_failure("1", {}, {"reason_code": "reg_rejected"}, 0.0)
         policy.classify.assert_called_once()

--- a/webui/src/views/VowifiHistory.jsx
+++ b/webui/src/views/VowifiHistory.jsx
@@ -125,19 +125,30 @@ export default function VowifiHistory({ instanceId, subscribe, compact = false }
   const [data, setData] = useState(null)
   const [error, setError] = useState('')
   const [hover, setHover] = useState(null)
+  const requestGeneration = useRef(0)
 
   const load = useCallback(() => {
+    const generation = ++requestGeneration.current
     if (!instanceId) return
     api.lineAvailability(instanceId)
-      .then(result => { setData(result); setError('') })
-      .catch(err => setError(err.message))
+      .then(result => {
+        if (generation !== requestGeneration.current) return
+        setData(result); setError('')
+      })
+      .catch(err => {
+        if (generation !== requestGeneration.current) return
+        setError(err.message)
+      })
   }, [instanceId])
 
   useEffect(() => {
-    setData(null); setHover(null)
+    setData(null); setHover(null); setError('')
     load()
     const timer = setInterval(load, REFRESH_MS)
-    return () => clearInterval(timer)
+    return () => {
+      ++requestGeneration.current
+      clearInterval(timer)
+    }
   }, [load])
 
   // Status events arrive every few seconds whether or not anything changed. Only a real

--- a/webui/tests/vowifi-history.test.mjs
+++ b/webui/tests/vowifi-history.test.mjs
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+const source = readFileSync(new URL('../src/views/VowifiHistory.jsx', import.meta.url), 'utf8')
+const body = source.slice(source.indexOf('export default function VowifiHistory'),
+  source.indexOf('  const segments = data?.segments'))
+  .replace('export default function', 'function')
+
+function harness() {
+  const slots = []
+  const requests = []
+  let cursor = 0
+  let effects = []
+  let cleanup = []
+  const context = {
+    useI18n: () => ({ t: value => value, language: 'en' }),
+    useState(initial) {
+      const index = cursor++
+      if (!(index in slots)) slots[index] = initial
+      return [slots[index], value => { slots[index] = value }]
+    },
+    useRef(initial) {
+      const index = cursor++
+      if (!(index in slots)) slots[index] = { current: initial }
+      return slots[index]
+    },
+    useCallback: callback => callback,
+    useEffect: effect => effects.push(effect),
+    setInterval: () => 1,
+    clearInterval: () => {},
+    REFRESH_MS: 30000,
+    api: {
+      lineAvailability(id) {
+        return new Promise((resolve, reject) => requests.push({ id, resolve, reject }))
+      },
+    },
+  }
+  vm.createContext(context)
+  vm.runInContext(`${body}\nreturn { load }\n}`, context)
+  return {
+    slots,
+    requests,
+    render(instanceId) {
+      cleanup.forEach(dispose => dispose?.())
+      cursor = 0
+      effects = []
+      const rendered = context.VowifiHistory({ instanceId })
+      cleanup = effects.map(effect => effect())
+      return rendered
+    },
+    unmount() { cleanup.forEach(dispose => dispose?.()) },
+  }
+}
+
+const settle = () => new Promise(resolve => setImmediate(resolve))
+
+test('a previous line cannot overwrite the current line', async () => {
+  const app = harness()
+  app.render('A')
+  app.render('B')
+  app.requests[1].resolve({ line: 'B' })
+  await settle()
+  app.requests[0].resolve({ line: 'A' })
+  await settle()
+  assert.equal(app.slots[0].line, 'B')
+})
+
+test('overlapping refreshes accept only the newest response or error', async () => {
+  const app = harness()
+  const rendered = app.render('A')
+  rendered.load()
+  app.requests[1].resolve({ version: 2 })
+  await settle()
+  app.requests[0].reject(new Error('stale error'))
+  await settle()
+  assert.equal(app.slots[0].version, 2)
+  assert.equal(app.slots[1], '')
+  rendered.load()
+  rendered.load()
+  app.requests[3].resolve({ version: 4 })
+  await settle()
+  app.requests[2].resolve({ version: 3 })
+  await settle()
+  assert.equal(app.slots[0].version, 4)
+})
+
+test('changing lines clears old errors and unmount invalidates requests', async () => {
+  const app = harness()
+  app.render('A')
+  app.requests[0].reject(new Error('A failed'))
+  await settle()
+  assert.equal(app.slots[1], 'A failed')
+  app.render('B')
+  assert.equal(app.slots[1], '')
+  app.unmount()
+  app.requests[1].resolve({ line: 'B' })
+  await settle()
+  assert.equal(app.slots[0], null)
+})


### PR DESCRIPTION
## Summary

This addresses six reviewed problems that could disrupt healthy lines, delay recovery, or display misleading information:

- Treat missing tunnel evidence and ambiguous failures conservatively; local DNS, SIM, protocol and engine faults must not strike an exit or trigger session cleanup.
- Bypass the exit ledger for direct and non-selectable routes, avoiding an hourly retry cycle for a candidate pool that does not exist.
- Persist an already-active selector default without restarting the shared sing-box process; actual configuration changes and dead processes still restart normally.
- Queue notification destinations independently on a dedicated eight-worker pool, keeping HTTP retries off the default executor.
- Prefer exact PLMN records, including parent-network fallback, over legacy padded-MNC compatibility.
- Reject obsolete VoWiFi-history successes and errors after refreshes, line changes and unmounts.

Includes regression tests and unreleased changelog entries. No Engine image changes are required.

## Validation

- Full local Python suite: 1,059 tests passed.
- Python compilation, shell syntax, subscriber-identifier scan and WebUI production build passed.
- ARM64 Raspberry Pi isolated regression run: 315 tests passed; one Node.js-dependent test skipped because Node.js is not installed on the device. The UI race tests passed locally.
- Deployed and observed on the development device: all three previously running lines remained CONNECTED / Registered with the same Engine containers and images; configuration and device intent were preserved; sing-box stayed on one PID during the observation window and proxy traffic continued.
- Served WebUI matches the new build. No real-call test or deliberate network-failure injection was performed.

## Safety and privacy impact

- [x] No real SIM identity, phone number, PIN, token, subscription URL, message or call data is included.
- [x] Device-changing operations fail closed and report actual state.
- [x] User-visible changes are documented.
- [x] Python tests and WebUI build pass.
