### PR TITLE
fix(failover): keep the exit ledger when a subscription node is momentarily unknown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ All notable changes follow Keep a Changelog and Semantic Versioning.
   failed exit nodes. Unknown evidence does not trigger node changes or stalled-session cleanup,
   and notifications no longer claim a clean tunnel when that has not been established.
 - Direct and non-selectable routes bypass the exit ledger instead of entering an hourly
-  candidate-exhaustion retry cycle.
+  candidate-exhaustion retry cycle. A subscription exit whose current node is momentarily
+  unknown (the host blanks it until the Clash API answers) keeps its ledger, so a freeze in
+  that window no longer restarts the candidate walk or repeats the exhaustion notification.
 - Persisting a subscription selector's already-active node no longer restarts the shared
   sing-box process. Actual configuration changes and process failures still trigger a restart.
 - Notification destinations run independently on a dedicated, eight-worker delivery pool;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ All notable changes follow Keep a Changelog and Semantic Versioning.
 - Missing tunnel evidence and local DNS, SIM, protocol or engine failures no longer count as
   failed exit nodes. Unknown evidence does not trigger node changes or stalled-session cleanup,
   and notifications no longer claim a clean tunnel when that has not been established.
+  Only a tunnel that went unanswered on the network (`tunnel_network`) with readable IKE
+  evidence now blames the exit. An ePDG that refuses the line before any EAP-AKA challenge
+  (`tunnel_not_authorized`), a setup failure with no clear cause, and a rekey that timed out
+  before the line had been stable for ten minutes are treated as inconclusive: the line keeps
+  rebuilding on its current exit and reports once after repeated failures instead of walking
+  the candidate pool. Previously an authorization refusal was attributed to the exit's source
+  address and moved the node; in practice those refusals have been carrier-side decisions
+  (location headers, IMEI binding, provisioning) that no other node fixes.
+- A partial or garbled EF.ICCID read is no longer treated as the card's identity. The control
+  plane, `pin_keeper`, `ami_usim` and `swu_ike` now require the full ten BCD bytes and an
+  all-digit value of at least fifteen digits; anything shorter reads as "could not identify
+  the card". Previously a truncated read decoded into a different number and could convict a
+  correctly bound reader as holding the wrong SIM, stranding the line
+  ([#69](https://github.com/MddIdd/mdd-sim-gateway/pull/69)).
 - Direct and non-selectable routes bypass the exit ledger instead of entering an hourly
   candidate-exhaustion retry cycle. A subscription exit whose current node is momentarily
   unknown (the host blanks it until the Clash API answers) keeps its ledger, so a freeze in

--- a/control/app/main.py
+++ b/control/app/main.py
@@ -1780,9 +1780,17 @@ def _judge_exit_failure(iid: str, inst: dict, st: dict, stable_for: float) -> st
     country = egress.line_country(inst)
     exits = (egress.status().get("exits") or {}).get(country) or {}
     if (not cfg.get_settings().get("proxy", {}).get("enabled", False)
-            or exits.get("mode") != "subscription" or not exits.get("node")):
+            or exits.get("mode") != "subscription"):
+        # Direct, single-node and disabled routes have no pool to walk, so a ledger for them
+        # is stale by definition.
         if hub.exit_ledgers.pop(iid, None) is not None:
             _save_exit_ledgers()
+        return failover.HOLD
+    if not exits.get("node"):
+        # A subscription exit whose node is momentarily unknown: the host blanks it on every
+        # status cycle until the Clash API answers, so a slow query or a sing-box restart
+        # leaves it empty for one cycle. That says nothing about the exit — keep the walk
+        # (tried, exhausted, given_up) intact and judge again on the next freeze.
         return failover.HOLD
     node = str(exits.get("node") or "")
     candidates = [str(name) for name in (exits.get("candidates") or [])]

--- a/tests/test_line_lifecycle.py
+++ b/tests/test_line_lifecycle.py
@@ -1154,6 +1154,24 @@ class ExitFailoverWiringTests(unittest.IsolatedAsyncioTestCase):
         reselect.assert_not_called()
         self.stalled.assert_not_called()
 
+    async def test_a_momentarily_unknown_subscription_node_keeps_the_walk(self):
+        # The host blanks the node on every status cycle until the Clash API answers, so a
+        # freeze can land on a cycle where the exit is known to be a subscription pool but
+        # its current member is not. That is no evidence: a backed-off or given-up walk must
+        # survive it unchanged, or the line re-walks the pool and notifies all over again.
+        ledger = {**main.failover.blank_ledger(), "node": "node-b", "strikes": 1,
+                  "tried": ["node-a", "node-b"], "exhausted": True, "given_up": True,
+                  "failures": 7, "reported": True}
+        main.hub.exit_ledgers["9"] = dict(ledger)
+        unknown = {"exits": {"us": {"node": "", "candidates": ["node-a", "node-b"],
+                                    "selection": "auto", "mode": "subscription"}}}
+        action, reselect, notify = self._judge("DOWN", 0, exits=unknown)
+        self.assertEqual(action, main.failover.HOLD)
+        self.assertEqual(main.hub.exit_ledgers["9"], ledger)
+        reselect.assert_not_called()
+        notify.assert_not_called()
+        self.stalled.assert_not_called()
+
     async def test_direct_freezes_keep_normal_retry_cadence(self):
         st = {"state": "TUNNEL_DOWN", "reason_code": "tunnel_network", "reason": "x"}
         with patch.object(main.egress, "status", return_value={"exits": {"us": {"mode": "direct"}}}), \


### PR DESCRIPTION
## Summary

Pre-release review of `develop` for v1.9.2 turned up one low-severity edge in the exit failover wiring and two changelog gaps.

- **Keep the ledger when a subscription node is momentarily unknown.** The host blanks a subscription exit's `node` on every status cycle until the Clash API answers, so a slow query (1.5 s timeout) or a sing-box restart leaves it empty for one cycle. `_judge_exit_failure` popped the whole ledger whenever `node` was empty, so a freeze in that window lost `tried` / `exhausted` / `given_up`: a backed-off line re-walked the candidate pool and repeated the exhaustion notification. Only direct, single-node and disabled routes discard the ledger now; an unknown node holds without touching it.
- **Changelog: PR #69** (partial EF.ICCID reads no longer convict a reader) had no entry.
- **Changelog: narrowed attribution.** PR #72 made `tunnel_not_authorized`, unexplained setup failures and early rekey timeouts inconclusive instead of blaming the exit. That is a deliberate policy change the entry only described as "unknown evidence"; it now says what changed and why.

## Test plan

- [x] New `test_a_momentarily_unknown_subscription_node_keeps_the_walk` in `tests/test_line_lifecycle.py`
- [x] Full suite: 1060 unittest pass; 3 webui node tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
