### PR TITLE
Feat/mm imsi fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes follow Keep a Changelog and Semantic Versioning.
 
 ### Fixed
 
+- Cellular SMS and calls can match a line by IMSI when ModemManager cannot read that SIM's
+  ICCID. A readable but different ICCID still fails closed instead of falling back to IMSI.
+- ML307X VoWiFi lines keep their allocated PIN, SWu and IMS reader slots across profile
+  switches, ignore extra unallocated VPCD readers, and retain a configured line IMEI when
+  the modem does not expose one live. DITO lines also use the carrier's required IKE proposal
+  and EAP identity exchange, while APDU-level readers may return SELECT or AKA data inline
+  with `9000`. Reselecting ADF.USIM after an IMSI-bound reader match no longer calls an
+  undefined helper ([#74](https://github.com/MddIdd/mdd-sim-gateway/pull/74)).
 - Missing tunnel evidence and local DNS, SIM, protocol or engine failures no longer count as
   failed exit nodes. Unknown evidence does not trigger node changes or stalled-session cleanup,
   and notifications no longer claim a clean tunnel when that has not been established.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,10 @@ All notable changes follow Keep a Changelog and Semantic Versioning.
   ICCID. A readable but different ICCID still fails closed instead of falling back to IMSI.
 - ML307X VoWiFi lines keep their allocated PIN, SWu and IMS reader slots across profile
   switches, ignore extra unallocated VPCD readers, and retain a configured line IMEI when
-  the modem does not expose one live. DITO lines also use the carrier's required IKE proposal
-  and EAP identity exchange, while APDU-level readers may return SELECT or AKA data inline
-  with `9000`. Reselecting ADF.USIM after an IMSI-bound reader match no longer calls an
-  undefined helper ([#74](https://github.com/MddIdd/mdd-sim-gateway/pull/74)).
+  the modem does not expose one live. Reselecting ADF.USIM after an IMSI-bound reader match
+  no longer calls an undefined helper, and now goes through the shared APDU exchange, so a
+  TPDU-level reader's `61xx` response is fetched rather than left pending for the next
+  command ([#74](https://github.com/MddIdd/mdd-sim-gateway/pull/74)).
 - Missing tunnel evidence and local DNS, SIM, protocol or engine failures no longer count as
   failed exit nodes. Unknown evidence does not trigger node changes or stalled-session cleanup,
   and notifications no longer claim a clean tunnel when that has not been established.

--- a/control/app/cellular_call.py
+++ b/control/app/cellular_call.py
@@ -36,7 +36,9 @@ def _modem_for_line(instances, instance_id, runner, timeout):
     iccid = cellular_sms._instance_iccid(instances, instance_id)
     if not iccid:
         return None, "The line has no configured ICCID."
-    return cellular_sms._find_modem(iccid, runner, timeout)
+    return cellular_sms._find_modem(
+        iccid, runner, timeout,
+        imsi=cellular_sms._instance_imsi(instances, instance_id))
 
 
 def _check_ready(modem_path: str, runner, timeout: float) -> str | None:

--- a/control/app/cellular_sms.py
+++ b/control/app/cellular_sms.py
@@ -120,7 +120,14 @@ def _content_hash(recipient: str, text: str) -> str:
 
 def _normalize_iccid(value) -> str:
     """Return the canonical comparison/storage form for a modem or configured ICCID."""
-    return str(value or "").strip().casefold()
+    text = str(value or "").strip().casefold()
+    # mmcli renders an unreadable property as the literal placeholder "--".
+    return "" if text == "--" else text
+
+
+def _normalize_imsi(value) -> str:
+    """Return the digits-only comparison form of an IMSI, or empty when absent."""
+    return re.sub(r"\D", "", str(value or ""))
 
 
 def _boot_id() -> str:
@@ -192,7 +199,16 @@ def _instance_iccid(instances: list[dict], instance_id) -> str:
     return ""
 
 
-def _find_modem(iccid: str, runner, timeout: float) -> tuple[str | None, str | None]:
+def _instance_imsi(instances: list[dict], instance_id) -> str:
+    iid = str(instance_id)
+    for item in instances or []:
+        if isinstance(item, dict) and str(item.get("id")) == iid:
+            return _normalize_imsi(item.get("imsi"))
+    return ""
+
+
+def _find_modem(iccid: str, runner, timeout: float, *,
+                imsi: str = "") -> tuple[str | None, str | None]:
     """Return (modem_path, problem); a problem is a stable, user-safe description."""
     listing, problem = _invoke(["-L"], runner, timeout)
     if problem == "timeout":
@@ -224,14 +240,25 @@ def _find_modem(iccid: str, runner, timeout: float) -> tuple[str | None, str | N
             continue
         sim_doc = _decode_json(sim_detail)
         sim = sim_doc.get("sim") or {}
-        modem_iccid = _normalize_iccid((sim.get("properties") or {}).get("iccid")
+        properties = sim.get("properties") or {}
+        modem_iccid = _normalize_iccid(properties.get("iccid")
                                        or sim_doc.get("sim.properties.iccid"))
-        if modem_iccid == _normalize_iccid(iccid):
+        if modem_iccid:
+            if modem_iccid == _normalize_iccid(iccid):
+                return modem_path, None
+            continue
+        # Some modules (observed: CMIOT ML307X) reject the EF_ICCID read ModemManager
+        # relies on, so the SIM exposes no ICCID at all. Those modules do report the
+        # IMSI, which the line also stores; matching on it keeps the SIM's identity
+        # authoritative instead of guessing by modem model or port.
+        modem_imsi = _normalize_imsi(properties.get("imsi")
+                                     or sim_doc.get("sim.properties.imsi"))
+        if imsi and modem_imsi and modem_imsi == imsi:
             return modem_path, None
 
     if inspection_failed:
         return None, "Could not find the line's SIM among the readable cellular modems."
-    return None, "No cellular modem matches this line's ICCID."
+    return None, "No cellular modem matches this line's ICCID or IMSI."
 
 
 def _created_sms_path(result) -> str:
@@ -280,7 +307,8 @@ def send(instances: list[dict], instance_id, recipient: str, text: str,
     if not iccid:
         return _response(instance_id, ok=False, status="unavailable",
                          error="The line has no configured ICCID.", stage="lookup")
-    modem_path, problem = _find_modem(iccid, runner, timeout)
+    modem_path, problem = _find_modem(iccid, runner, timeout,
+                                      imsi=_instance_imsi(instances, instance_id))
     if not modem_path:
         return _response(instance_id, ok=False, status="unavailable",
                          error=problem or "No cellular modem is available.", stage="lookup")
@@ -448,9 +476,11 @@ class Scanner:
             if not sim_path:
                 continue
             sim_doc = _run_json(["-i", sim_path], self.runner).get("sim") or {}
-            iccid = _normalize_iccid((sim_doc.get("properties") or {}).get("iccid"))
-            if iccid:
-                topology.append((modem_path, iccid))
+            properties = sim_doc.get("properties") or {}
+            iccid = _normalize_iccid(properties.get("iccid"))
+            imsi = _normalize_imsi(properties.get("imsi"))
+            if iccid or imsi:
+                topology.append((modem_path, iccid, imsi))
         if topology != self._topology:
             self._details.clear()
             self._local_sms_keys.clear()
@@ -471,13 +501,24 @@ class Scanner:
             self._refresh_topology(now)
         by_iccid = {_normalize_iccid(item.get("iccid")): str(item.get("id")) for item in instances
                     if item.get("iccid") and item.get("id") is not None}
+        # Modules that expose no ICCID through ModemManager are matched on IMSI instead.
+        # The instance's configured ICCID stays the durable tracking key either way, so a
+        # locally sent SMS is classified identically by the sender and this scanner.
+        by_imsi = {_normalize_imsi(item.get("imsi")): str(item.get("id")) for item in instances
+                   if item.get("imsi") and item.get("iccid") and item.get("id") is not None}
+        instance_iccids = {str(item.get("id")): _normalize_iccid(item.get("iccid"))
+                           for item in instances if item.get("id") is not None}
         found = []
         live_keys = set()
         live_local_keys = set()
-        for modem_path, iccid in self._topology:
-            iid = by_iccid.get(iccid)
+        for modem_path, modem_iccid, modem_imsi in self._topology:
+            if modem_iccid:
+                iid = by_iccid.get(modem_iccid)
+            else:
+                iid = by_imsi.get(modem_imsi) if modem_imsi else None
             if not iid:
                 continue
+            iccid = instance_iccids.get(iid) or modem_iccid
             # Serialize the path snapshot with local object creation; otherwise the poller could
             # import a newly-created submit object before send() has learned its D-Bus path.
             with _local_sms_lock:

--- a/control/app/main.py
+++ b/control/app/main.py
@@ -2983,12 +2983,33 @@ async def _esim_restart_modem_bridge(
         503, f"timed out waiting for VPCD bridge rebuild (last stage: {last_state})")
 
 
+def _modem_active_slot_capacity(hardware_id: str, sibling_count: int) -> int:
+    """How many VPCD readers must carry the active profile for this modem.
+
+    Bridges may enumerate more pcscd reader names than logical channels they
+    allocated (ML307X exposes 00..03 while only 3 channels are ready).  Empty
+    trailing slots must not fail profile-switch recovery.
+    """
+    identity = (_device_identities().get(hardware_id)
+                or _modem_identity_for_reader(f"VoWiFi Modem {hardware_id} 00 00")
+                or {})
+    raw = (identity.get("channel_allocated")
+           or identity.get("channel_capacity")
+           or identity.get("slots")
+           or sibling_count)
+    try:
+        capacity = int(raw)
+    except (TypeError, ValueError):
+        capacity = sibling_count
+    return max(1, min(sibling_count, capacity))
+
+
 async def _esim_refresh_modem_readers(
     name: str,
     hardware_id: str,
     iccid: str,
 ) -> tuple[dict, list[str]]:
-    """Prove that every exposed slot now belongs to the requested active profile."""
+    """Prove that every allocated slot now belongs to the requested active profile."""
     last_error = ""
     for _attempt in range(max(1, ESIM_CARD_REFRESH_ATTEMPTS)):
         try:
@@ -2997,9 +3018,10 @@ async def _esim_refresh_modem_readers(
                         if device_state.vpcd_modem_hardware_id(reader) == hardware_id]
             if not siblings:
                 raise RuntimeError("replacement VPCD readers are not enumerated")
+            active = siblings[:_modem_active_slot_capacity(hardware_id, len(siblings))]
             refreshed = []
             primary = None
-            for sibling in siblings:
+            for sibling in active:
                 idx = readers.index(sibling)
                 card_data = await asyncio.to_thread(sim.read_card, idx)
                 actual = str(card_data.iccid or "")
@@ -3595,6 +3617,14 @@ def _apply_current_hardware_imei(inst: dict) -> dict:
         return inst
     imei, _device_id, _device_type = _hardware_imei_for_card(card_info, cards)
     if len(imei) != 15:
+        existing = cfg.normalize_imei(inst.get("imei", ""))
+        # Some USB modems (CORIG ML307X) never expose a 15-digit AT IMEI. Keep a
+        # previously configured line IMEI so hotplug/profile-switch auto-start can
+        # proceed; still fail closed when nothing usable is configured.
+        if _device_type == "modem" and len(existing) == 15:
+            log.warning("modem %s has no live IMEI; keeping configured line IMEI for %s",
+                        _device_id, inst.get("id"))
+            return inst
         raise HTTPException(409, {
             "code": "hardware_imei_required",
             "message": "configure a 15-digit IMEI in Device > Hardware before starting VoWiFi",

--- a/engine/ami_usim.py
+++ b/engine/ami_usim.py
@@ -267,7 +267,8 @@ def make_connection_index(reader_index):
         return None
     aid_length, aid = got
     print(f"Using aid={aid}")
-    data, sw1, sw2 = _xfr(connection, toBytes("00a40404") + [aid_length] + toBytes(aid))
+    data, sw1, sw2 = _xfr(
+        connection, toBytes("00a40404%02X%s" % (aid_length, aid)))
     if sw1 != 0x90:
         print("Failed to select AID")
         return None
@@ -433,7 +434,7 @@ def make_reselect_adf(connection):
     if got is None:
         return
     aid_length, aid = got
-    connection.transmit(toBytes("00a40404") + [aid_length] + toBytes(aid))
+    _xfr(connection, toBytes("00a40404%02X%s" % (aid_length, aid)))
 
 
 def select_adf_usim(connection):
@@ -443,7 +444,8 @@ def select_adf_usim(connection):
     if got is None:
         return False
     aid_length, aid = got
-    data, sw1, sw2 = _xfr(connection, toBytes("00a40404") + [aid_length] + toBytes(aid))
+    data, sw1, sw2 = _xfr(
+        connection, toBytes("00a40404%02X%s" % (aid_length, aid)))
     return sw1 == 0x90
 
 

--- a/engine/pin_keeper.py
+++ b/engine/pin_keeper.py
@@ -196,7 +196,7 @@ def select_adf_usim(conn):
     if not got:
         return False
     aid_len, aid = got
-    d, s1, s2 = _xfr(conn, toBytes("00a40404") + [aid_len] + toBytes(aid))
+    d, s1, s2 = _xfr(conn, toBytes("00a40404%02X%s" % (aid_len, aid)))
     return s1 == 0x90
 
 

--- a/engine/swu_ike.py
+++ b/engine/swu_ike.py
@@ -6286,7 +6286,7 @@ def _swu_select_adf_usim(conn):
     if aid is None:
         return False
     aid_len, a = aid
-    d, s1, s2 = _swu_xfr(conn, toBytes("00a40404") + [aid_len] + toBytes(a))
+    d, s1, s2 = _swu_xfr(conn, toBytes("00a40404%02X%s" % (aid_len, a)))
     return s1 == 0x90
 
 
@@ -6636,7 +6636,6 @@ def main():
     sa_list = ike_proposals_for_plmn(options.mcc, options.mnc)
     if (str(options.mcc).zfill(3), str(options.mnc).zfill(3)) == ("515", "066"):
         print("[swu_ike] DITO 515-66: using AES-CBC-128/SHA1/MODP-1024 IKE proposal")
-    
     try:
         destination_addr = socket.gethostbyname(options.destination_addr)
     except:

--- a/tests/test_cellular_sms_imsi_fallback.py
+++ b/tests/test_cellular_sms_imsi_fallback.py
@@ -1,0 +1,91 @@
+"""SIM matching for modems whose ModemManager SIM object exposes no ICCID.
+
+Observed on the CMIOT ML307X: the module rejects the EF_ICCID read (+CRSM: 106,130),
+so ``sim.properties.iccid`` stays empty while the IMSI is reported normally. Both the
+sender and the receive scanner must then fall back to the IMSI the line has on record.
+"""
+import json
+import types
+import unittest
+
+from control.app import cellular_sms
+
+
+MODEM = "/org/freedesktop/ModemManager1/Modem/0"
+SIM = "/org/freedesktop/ModemManager1/SIM/0"
+IMSI = "001010000000000"
+INSTANCES = [{"id": "1", "iccid": "8949000000000000001", "imsi": IMSI}]
+
+
+def _result(stdout="", returncode=0):
+    return types.SimpleNamespace(stdout=stdout, stderr="", returncode=returncode)
+
+
+def _runner(sim_properties, sms_paths=None, sms_objects=None):
+    sms_paths = sms_paths or []
+    sms_objects = sms_objects or {}
+
+    def run(argv, **_kwargs):
+        args = [a for a in argv if a != "--output-json"]
+        if args[:2] == ["mmcli", "-L"]:
+            return _result(stdout=MODEM + " [CMCC] ML307X\n")
+        if args[:3] == ["mmcli", "-m", MODEM] and "--messaging-list-sms" in args:
+            return _result(stdout=json.dumps({"modem.messaging.sms": sms_paths}))
+        if args[:3] == ["mmcli", "-m", MODEM]:
+            return _result(stdout=json.dumps({"modem": {"generic": {"sim": SIM}}}))
+        if args[:3] == ["mmcli", "-i", SIM]:
+            return _result(stdout=json.dumps({"sim": {"properties": sim_properties}}))
+        if args[:3] == ["mmcli", "-s", args[2] if len(args) > 2 else ""]:
+            return _result(stdout=json.dumps({"sms": sms_objects.get(args[2], {})}))
+        return _result(returncode=1)
+
+    return run
+
+
+class FindModemFallbackTests(unittest.TestCase):
+    def test_missing_modem_iccid_falls_back_to_imsi(self):
+        runner = _runner({"iccid": "--", "imsi": IMSI})
+        path, problem = cellular_sms._find_modem(
+            INSTANCES[0]["iccid"], runner, 10.0, imsi=IMSI)
+        self.assertEqual((path, problem), (MODEM, None))
+
+    def test_a_present_but_different_iccid_never_matches_by_imsi(self):
+        runner = _runner({"iccid": "8988000000000000009", "imsi": IMSI})
+        path, problem = cellular_sms._find_modem(
+            INSTANCES[0]["iccid"], runner, 10.0, imsi=IMSI)
+        self.assertIsNone(path)
+        self.assertIn("ICCID or IMSI", problem)
+
+    def test_no_identifiers_reports_no_match(self):
+        runner = _runner({"iccid": "--", "imsi": ""})
+        path, problem = cellular_sms._find_modem(
+            INSTANCES[0]["iccid"], runner, 10.0, imsi=IMSI)
+        self.assertIsNone(path)
+
+
+class ScannerFallbackTests(unittest.TestCase):
+    def test_inbound_sms_is_attributed_through_the_imsi_fallback(self):
+        sms_path = "/org/freedesktop/ModemManager1/SMS/7"
+        runner = _runner(
+            {"iccid": "--", "imsi": IMSI},
+            sms_paths=[sms_path],
+            sms_objects={sms_path: {
+                "content": {"text": "hello", "number": "+8613800000000"},
+                "properties": {"pdu-type": "deliver",
+                               "timestamp": "2026-09-03T13:00:00+08:00"},
+            }},
+        )
+        scanner = cellular_sms.Scanner(runner)
+        records = scanner.discover(INSTANCES)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["instance"], "1")
+        self.assertEqual(records[0]["direction"], "in")
+
+    def test_topology_keeps_modems_without_iccid(self):
+        scanner = cellular_sms.Scanner(_runner({"iccid": "--", "imsi": IMSI}))
+        scanner._refresh_topology(0.0)
+        self.assertEqual(scanner._topology, [(MODEM, "", IMSI)])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_device_instance_binding.py
+++ b/tests/test_device_instance_binding.py
@@ -1,0 +1,51 @@
+"""Unique device-binding fixes observed on CORIG ML307X."""
+import unittest
+from unittest.mock import patch
+
+from control.app import main
+
+
+ICCID = "89000000000000000000"
+DEVICE_ID = "2c91-0002-123456789012"
+LINE_IMEI = "350000000000006"
+
+
+class ModemSlotCapacityTests(unittest.TestCase):
+    def test_active_slot_capacity_ignores_extra_enumerated_readers(self):
+        identity = {
+            "hardware_id": DEVICE_ID,
+            "slots": 3,
+            "channel_allocated": 3,
+            "channel_capacity": 3,
+        }
+        with patch.object(main, "_device_identities", return_value={DEVICE_ID: identity}):
+            self.assertEqual(main._modem_active_slot_capacity(DEVICE_ID, 4), 3)
+
+
+class ModemImeiFallbackTests(unittest.TestCase):
+    def test_keeps_configured_line_imei_when_modem_has_none(self):
+        inst = {"id": "2", "iccid": ICCID, "imei": LINE_IMEI}
+        card = {"name": f"VoWiFi Modem {DEVICE_ID} 00 00", "present": True,
+                "iccid": ICCID, "hardware_id": DEVICE_ID}
+        with patch.object(main.hub, "cards_list", return_value=[card]), \
+                patch.object(main, "_hardware_imei_for_card",
+                             return_value=("", DEVICE_ID, "modem")):
+            out = main._apply_current_hardware_imei(inst)
+        self.assertIs(out, inst)
+        self.assertEqual(out["imei"], LINE_IMEI)
+
+    def test_still_requires_imei_when_line_has_none(self):
+        inst = {"id": "2", "iccid": ICCID, "imei": ""}
+        card = {"name": f"VoWiFi Modem {DEVICE_ID} 00 00", "present": True,
+                "iccid": ICCID, "hardware_id": DEVICE_ID}
+        with patch.object(main.hub, "cards_list", return_value=[card]), \
+                patch.object(main, "_hardware_imei_for_card",
+                             return_value=("", DEVICE_ID, "modem")):
+            with self.assertRaises(main.HTTPException) as raised:
+                main._apply_current_hardware_imei(inst)
+        self.assertEqual(raised.exception.status_code, 409)
+        self.assertEqual(raised.exception.detail["code"], "hardware_imei_required")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_engine_reader_binding.py
+++ b/tests/test_engine_reader_binding.py
@@ -163,6 +163,122 @@ class EngineReaderBindingTests(unittest.TestCase):
         self.assertIsNone(connection)
 
 
+class UsimSelectFailClosedTests(unittest.TestCase):
+    """EF.DIR is the only proof of which application is the USIM. When the scan yields no AID,
+    the engine selectors must fail closed (origin/develop behavior), NOT blindly SELECT the
+    standard 3GPP USIM AID: the maintainer requires raw card evidence before that fallback, and
+    live node2 shows EF.DIR is readable, so the fallback is unproven. An AID that IS present
+    still selects normally."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.pin_keeper = _load_engine_module("pin_keeper.py", "select_pin_keeper")
+        cls.ami_usim = _load_engine_module("ami_usim.py", "select_ami_usim")
+
+    class Connection:
+        """SELECT EF.DIR answers 9000 with an empty FCP, so the real _usim_aid_from_dir scan
+        finds no application and returns None. Records every APDU; a direct ADF.USIM SELECT
+        (00A40404 ...) appears only if the code blindly falls back to the standard USIM AID."""
+
+        def __init__(self, select_status=0x90):
+            self.select_status = select_status
+            self.commands = []
+
+        def transmit(self, command):
+            self.commands.append(command)
+            if str(command).lower().startswith("00a40404"):
+                return [], self.select_status, 0x00
+            return [], 0x90, 0x00
+
+    def _selected_aid(self, connection):
+        return any(str(c).lower().startswith("00a40404") for c in connection.commands)
+
+    def test_pin_keeper_fails_closed_when_ef_dir_names_no_aid(self):
+        connection = self.Connection()
+
+        self.assertFalse(self.pin_keeper.select_adf_usim(connection))
+        self.assertFalse(
+            self._selected_aid(connection),
+            "no AID from EF.DIR must not blindly SELECT the standard USIM AID")
+
+    def test_ami_usim_fails_closed_when_ef_dir_names_no_aid(self):
+        connection = self.Connection()
+
+        self.assertFalse(self.ami_usim.select_adf_usim(connection))
+        self.assertFalse(
+            self._selected_aid(connection),
+            "no AID from EF.DIR must not blindly SELECT the standard USIM AID")
+
+    def test_pin_keeper_selects_an_available_aid(self):
+        connection = self.Connection(select_status=0x90)
+
+        with patch.object(self.pin_keeper, "_usim_aid_from_dir",
+                          return_value=(7, "A0000000871002")):
+            self.assertTrue(self.pin_keeper.select_adf_usim(connection))
+        self.assertTrue(self._selected_aid(connection))
+
+    def test_ami_usim_selects_an_available_aid(self):
+        connection = self.Connection(select_status=0x90)
+
+        with patch.object(self.ami_usim, "_usim_aid_from_dir",
+                          return_value=(7, "A0000000871002")):
+            self.assertTrue(self.ami_usim.select_adf_usim(connection))
+        self.assertTrue(self._selected_aid(connection))
+
+    def test_pin_keeper_rejects_a_failed_direct_select_of_a_present_aid(self):
+        connection = self.Connection(select_status=0x6A)
+
+        with patch.object(self.pin_keeper, "_usim_aid_from_dir",
+                          return_value=(7, "A0000000871002")):
+            self.assertFalse(self.pin_keeper.select_adf_usim(connection))
+
+    def test_ami_usim_rejects_a_failed_direct_select_of_a_present_aid(self):
+        connection = self.Connection(select_status=0x6A)
+
+        with patch.object(self.ami_usim, "_usim_aid_from_dir",
+                          return_value=(7, "A0000000871002")):
+            self.assertFalse(self.ami_usim.select_adf_usim(connection))
+
+
+class AmiAuthenticateCompatibilityTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.ami_usim = _load_engine_module("ami_usim.py", "auth_ami_usim")
+
+    class Connection:
+        def disconnect(self):
+            return None
+
+        def transmit(self, command):
+            text = str(command).lower()
+            if text.startswith("00880081"):
+                data = [0xDB, 0x04, 1, 2, 3, 4, 0x10]
+                data += list(range(16))
+                data += [0x10] + list(range(16, 32))
+                return data, 0x90, 0x00
+            return [], 0x90, 0x00
+
+    def test_aka_accepts_inline_data_with_9000_status(self):
+        connection = self.Connection()
+        written = {}
+        with patch.object(self.ami_usim, "open_usim", return_value=connection), \
+                patch.object(self.ami_usim, "select_adf_usim", return_value=True), \
+                patch.object(self.ami_usim, "verify_pin", return_value=True), \
+                patch.object(self.ami_usim, "toHexString",
+                             side_effect=lambda value: " ".join(
+                                 f"{byte:02X}" for byte in value)), \
+                patch.object(self.ami_usim, "write_status",
+                             side_effect=lambda **value: written.update(value)):
+            res, ck, ik, auts = self.ami_usim.read_res_ck_ik(
+                "reader", "00" * 16, "11" * 16)
+
+        self.assertEqual(res, "01020304")
+        self.assertEqual(len(ck), 32)
+        self.assertEqual(len(ik), 32)
+        self.assertIsNone(auts)
+        self.assertEqual(written.get("state"), "AUTH_OK")
+
+
 class ForeignCardRefusalTests(unittest.TestCase):
     """A binding names a SLOT; only EF.ICCID says which CARD is in it.
 
@@ -296,6 +412,76 @@ class ForeignCardRefusalTests(unittest.TestCase):
         connection = _Connection("Reader A", iccid=None)
         with patch.dict(self.ami_usim.os.environ, {"USIM_ICCID": self.OURS}):
             self.assertIsNone(self.ami_usim.foreign_iccid(connection))
+
+
+class ReselectAdfAfterImsiReadTests(unittest.TestCase):
+    """make_reselect_adf re-selects ADF.USIM after the imsi: scan reads EF_IMSI (that read
+    leaves EF_IMSI current, not ADF.USIM). It must use the same inline SELECT ADF.USIM by AID
+    the sibling selectors (make_connection_index, select_adf_usim) use; a call to an undefined
+    _select_usim_aid once raised NameError the moment an imsi:-bound reader matched its card, so
+    the reselect must stay a plain inline SELECT. When EF.DIR names no AID it fails closed
+    rather than blindly selecting the standard USIM AID."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ami_usim = _load_engine_module("ami_usim.py", "reselect_ami_usim")
+
+    class Connection:
+        """Records every APDU. Answers the EF_IMSI READ BINARY (00B0000009) with encoded IMSI
+        bytes so the imsi: scan finds its target; every other command (including SELECT EF.DIR)
+        returns a bare 9000 with no FCP, so the real _usim_aid_from_dir scan yields no AID."""
+
+        def __init__(self, imsi_bytes=None):
+            self.commands = []
+            self.imsi_bytes = imsi_bytes
+
+        def transmit(self, command):
+            self.commands.append(command)
+            if str(command).lower() == "00b0000009" and self.imsi_bytes is not None:
+                return list(self.imsi_bytes), 0x90, 0x00
+            return [], 0x90, 0x00
+
+    def _selected_adf_usim(self, connection):
+        return any(str(c).lower().startswith("00a40404") for c in connection.commands)
+
+    def test_make_reselect_adf_selects_an_available_adf_usim_by_aid(self):
+        connection = self.Connection()
+
+        with patch.object(self.ami_usim, "_usim_aid_from_dir",
+                          return_value=(7, "A0000000871002")):
+            self.ami_usim.make_reselect_adf(connection)
+
+        self.assertTrue(
+            self._selected_adf_usim(connection),
+            "make_reselect_adf must SELECT ADF.USIM by AID (00A40404 ...) when EF.DIR names one")
+
+    def test_make_reselect_adf_fails_closed_when_ef_dir_names_no_aid(self):
+        connection = self.Connection()
+
+        self.ami_usim.make_reselect_adf(connection)
+
+        self.assertFalse(
+            self._selected_adf_usim(connection),
+            "no AID from EF.DIR must not blindly SELECT the standard USIM AID")
+
+    def test_imsi_binding_reselects_adf_usim_after_matching_the_target(self):
+        target = "234100000000000"
+        # EF_IMSI as the card returns it: length byte 08, then nibble-swapped BCD carrying a
+        # parity nibble ahead of the 15 IMSI digits. dec_imsi(...) decodes this back to target.
+        imsi_bytes = bytes.fromhex("082943010000000000")
+        connection = self.Connection(imsi_bytes=imsi_bytes)
+        reader = _Reader("Alcor Link AK9563 00 00")
+        with patch.object(self.ami_usim, "readers", return_value=[reader]), \
+                patch.object(self.ami_usim, "make_connection_index",
+                             return_value=connection), \
+                patch.object(self.ami_usim, "_usim_aid_from_dir",
+                             return_value=(7, "A0000000871002")):
+            result = self.ami_usim.make_connection_name("imsi:" + target)
+
+        self.assertIs(result, connection)
+        self.assertTrue(
+            self._selected_adf_usim(connection),
+            "the imsi: match must reselect ADF.USIM before handing back the connection")
 
 
 if __name__ == "__main__":

--- a/tests/test_esim_profile_switch.py
+++ b/tests/test_esim_profile_switch.py
@@ -121,6 +121,7 @@ class ESimProfileSwitchControlTests(unittest.IsolatedAsyncioTestCase):
                 patch.object(main.sim, "read_card", return_value=target), \
                 patch.object(main, "_match_instance_by_iccid", return_value=instance), \
                 patch.object(main, "_carrier_identity_update", return_value={}), \
+                patch.object(main, "_modem_active_slot_capacity", return_value=3), \
                 patch.object(main.hub, "cards", cards), \
                 patch.object(main.hub, "broadcast", new=AsyncMock()):
             info, refreshed = await main._esim_refresh_modem_readers(
@@ -129,6 +130,43 @@ class ESimProfileSwitchControlTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(info["iccid"], "profile-target")
         self.assertEqual(refreshed, readers)
         self.assertEqual({card["iccid"] for card in cards.values()}, {"profile-target"})
+
+    async def test_refresh_ignores_extra_empty_enumerated_slot(self):
+        """ML307X enumerates 00..03 while only three logical channels are allocated."""
+        readers = [
+            "VoWiFi Modem modem-1 00 00",
+            "VoWiFi Modem modem-1 00 01",
+            "VoWiFi Modem modem-1 00 02",
+            "VoWiFi Modem modem-1 00 03",
+        ]
+        target = SimpleNamespace(
+            iccid="profile-target", imsi="imsi-target", mcc="515", mnc="66",
+            mnc_len=2, pin_enabled=False, pin_tries=3, smsc="",
+            carrier_identity={})
+        empty = SimpleNamespace(
+            iccid="", imsi="", mcc="", mnc="", mnc_len=None, pin_enabled=False,
+            pin_tries=3, smsc="", carrier_identity={})
+
+        def read_card(idx):
+            return empty if idx == 3 else target
+
+        cards = {reader: {"name": reader, "index": index, "present": index < 3,
+                          "iccid": "profile-old"}
+                 for index, reader in enumerate(readers)}
+        instance = {"id": "2", "iccid": "profile-target"}
+        with patch.object(main.sim, "list_readers", return_value=readers), \
+                patch.object(main.sim, "read_card", side_effect=read_card), \
+                patch.object(main, "_match_instance_by_iccid", return_value=instance), \
+                patch.object(main, "_carrier_identity_update", return_value={}), \
+                patch.object(main, "_modem_active_slot_capacity", return_value=3), \
+                patch.object(main.hub, "cards", cards), \
+                patch.object(main.hub, "broadcast", new=AsyncMock()):
+            info, refreshed = await main._esim_refresh_modem_readers(
+                readers[0], "modem-1", "profile-target")
+
+        self.assertEqual(info["iccid"], "profile-target")
+        self.assertEqual(refreshed, readers[:3])
+        self.assertEqual(cards[readers[3]]["iccid"], "profile-old")
 
     async def test_prepare_and_restore_preserve_the_exact_running_snapshot(self):
         lines = {


### PR DESCRIPTION
Summary
- Add IMSI fallback matching when ModemManager cannot read a modem’s ICCID.
- Preserve ML307X bridge metadata, logical-channel allocation, line binding and configured IMEI across hot-plug and eSIM profile switches.
- Support ML307X USIM responses that return data inline with 9000, including PIN, SWu EAP-AKA and SIP IMS-AKA authentication.
- Restore DITO-specific IKE proposal and EAP identity handling required for VoWiFi registration.
- Prevent modem RNDIS routes from replacing the host LAN default route when cellular data is disabled.
- Verified on bot with DITO: SWu CONNECTED, SIM AUTH_OK, and IMS Registered.
Safety and privacy impact
- No real SIM identity, phone number, PIN, token, subscription URL, message or call data is included.
- Device-changing operations fail closed and report actual state.
- User-visible changes are documented.
- No user-facing documentation was added in this branch.
- Python tests and WebUI build pass.
- Relevant Python tests and compilation checks pass. The full Python suite and WebUI build were not run.