### PR TITLE
fix(modem): stop unreadable modem properties and unmanaged data profiles from causing harm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ All notable changes follow Keep a Changelog and Semantic Versioning.
   attempting compatibility with older zero-padded two-digit MNCs.
 - VoWiFi history ignores stale request successes and failures after a newer refresh, line
   change or unmount, and clears the previous line's error when switching lines.
+- A SIM whose ICCID ModemManager could not read is treated as unidentified instead of as a
+  line that matches nothing. `mmcli` renders an unreadable property as the literal `--`;
+  that value reached the control plane as a live ICCID, so the modem never fell through to
+  the PC/SC bridge, which can still read the card over a logical channel.
+- A modem that reports no IMEI keeps its published bridge identity. The record was discarded
+  whenever the module never answered the AT IMEI query, which also dropped the bridge's ICCID
+  (so the card matched no line and the reader binding never migrated) and collapsed the modem
+  to a single VPCD slot, putting PIN, SWu and IMS on one reader.
 
 ## [1.9.1] - 2026-09-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,16 @@ All notable changes follow Keep a Changelog and Semantic Versioning.
   line that matches nothing. `mmcli` renders an unreadable property as the literal `--`;
   that value reached the control plane as a live ICCID, so the modem never fell through to
   the PC/SC bridge, which can still read the card over a logical channel.
+- A modem's cellular-data profile no longer autoconnects, and no longer offers the host a
+  default route. NetworkManager dialled the profile after a reboot however the operator had
+  set that modem's cellular-data switch, and nothing kept the result from carrying the
+  default route -- which would send the VoWiFi tunnel authenticating that very SIM out
+  through the SIM's own carrier. Profiles written by earlier versions are corrected in
+  place. Set `MDD_MODEM_ALLOW_DEFAULT_ROUTE=1` where the modem genuinely is the only uplink.
+- Turning cellular data off now reaches a modem that reports no port. The profile was matched
+  only by the port it was attached to, so a modem in a failed or SIM-less ModemManager state
+  -- the state in which an autoconnecting profile is most likely to be dialling on its own --
+  was left running.
 - A modem that reports no IMEI keeps its published bridge identity. The record was discarded
   whenever the module never answered the AT IMEI query, which also dropped the bridge's ICCID
   (so the card matched no line and the reader binding never migrated) and collapsed the modem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ All notable changes follow Keep a Changelog and Semantic Versioning.
   default route -- which would send the VoWiFi tunnel authenticating that very SIM out
   through the SIM's own carrier. Profiles written by earlier versions are corrected in
   place. Set `MDD_MODEM_ALLOW_DEFAULT_ROUTE=1` where the modem genuinely is the only uplink.
+- A cellular profile left behind by an earlier version is secured even when cellular data is
+  simply switched off. Every data path is gated on the ModemManager backend being up, so the
+  state an operator reaches by turning cellular data off -- backend stood down, profile left
+  behind -- was the one state in which nothing corrected a profile that still autoconnected
+  forever.
 - Turning cellular data off now reaches a modem that reports no port. The profile was matched
   only by the port it was attached to, so a modem in a failed or SIM-less ModemManager state
   -- the state in which an autoconnecting profile is most likely to be dialling on its own --

--- a/control/app/main.py
+++ b/control/app/main.py
@@ -158,9 +158,13 @@ def _modem_identity_for_reader(reader_name: str | None) -> dict | None:
             with open(path, encoding="utf-8") as handle:
                 identity = json.load(handle)
             if str(identity.get("hardware_id") or "") == hardware_id:
+                # A modem that never reports a 15-digit AT IMEI is a supported state -- the
+                # bridge publishes the identity with an empty IMEI on purpose. Discarding the
+                # whole record over it dropped the bridge's ICCID (so the card never matched a
+                # line and the reader binding never migrated) and collapsed the modem to the
+                # one-slot fallback below, putting PIN/SWu/IMS on a single VPCD reader.
                 imei = cfg.normalize_imei(identity.get("imei", ""))
-                if len(imei) == 15:
-                    return {**identity, "imei": imei}
+                return {**identity, "imei": imei if len(imei) == 15 else ""}
         except (OSError, ValueError, TypeError):
             continue
     # The generated reader can outlive bridge metadata across an unplug/restart.

--- a/host/mdd_orchestrator.py
+++ b/host/mdd_orchestrator.py
@@ -617,6 +617,8 @@ class Orchestrator:
         # legacy profile is a one-off; without this the data-off path would shell out to nmcli
         # on every reconcile to rewrite settings that already say what we want.
         self.modem_profile_policed: set[str] = set()
+        # Cleared whenever the cellular backend is up, so standing it back down re-sweeps.
+        self.modem_profiles_swept = False
         self.applied_timezone = ""
         self.obsolete_services_retired = False
         self.reader_config_path = Path(os.environ.get(
@@ -1664,6 +1666,44 @@ class Orchestrator:
         for name, device in active:
             if name == profile or (primary and device == primary):
                 run(["nmcli", "connection", "down", name])
+
+    def police_orphaned_modem_profiles(self) -> None:
+        """Apply the profile policy to modem profiles nothing else is watching.
+
+        Every ensure/disconnect call sits behind ``through_modemmanager``, which is false
+        whenever no device wants cellular data. So the state an operator reaches by simply
+        turning cellular data off -- ModemManager stood down, the GSM profile left behind --
+        is the one state in which nothing corrects that profile, and a profile written by an
+        earlier version says "autoconnect: forever" in it. That is the most dangerous place
+        to leave it: the operator has said no, nothing is supervising, and NetworkManager
+        still dials on its own the moment the modem enumerates.
+
+        Swept once per stand-down rather than per cycle; profiles are only ever created by
+        ensure_modem_data, which polices them as it goes.
+        """
+        if self.modem_profiles_swept:
+            return
+        self.modem_profiles_swept = True
+        result = run(["nmcli", "-t", "-f", "NAME,TYPE", "connection", "show"])
+        if result.returncode:
+            self.modem_profiles_swept = False
+            return
+        for line in (result.stdout or "").splitlines():
+            name, _, kind = line.rpartition(":")
+            name = name.replace(r"\:", ":")
+            if kind != "gsm" or not name.startswith("mdd-cell-"):
+                continue
+            if name in self.modem_profile_policed:
+                continue
+            outcome = run(["nmcli", "connection", "modify", name,
+                           *self.modem_profile_policy()])
+            if outcome.returncode:
+                self.log(f"could not secure leftover cellular profile {name}: "
+                         f"{(outcome.stderr or outcome.stdout).strip()}")
+                continue
+            self.modem_profile_policed.add(name)
+            self.log(f"secured leftover cellular profile {name} "
+                     "(no autoconnect, never the default route)")
 
     def apply_cellular_backend(self, enabled: bool, *, reset_modems: bool = True):
         """Apply the shared cellular backend required by one or more physical modems.
@@ -3111,6 +3151,11 @@ class Orchestrator:
 
             self.apply_device_radios(discovered, active_desired,
                                      through_modemmanager=cellular_required)
+            if cellular_required:
+                self.modem_profiles_swept = False
+            else:
+                # Nothing above ran: every data path is gated on the backend being up.
+                self.police_orphaned_modem_profiles()
             # Country egress only exists to carry VoWiFi IKE/ePDG traffic.
             proxy_desired = desired
             if not vowifi_required:

--- a/host/mdd_orchestrator.py
+++ b/host/mdd_orchestrator.py
@@ -1437,6 +1437,22 @@ class Orchestrator:
         return match.group(1).strip() if match else ""
 
     @staticmethod
+    def normalize_iccid(value: str) -> str:
+        """Return a usable SIM ICCID from a ModemManager property, or "".
+
+        mmcli renders a property it could not read as the literal placeholder "--"
+        (observed when a module rejects the EF_ICCID read). That is "unknown", not an
+        identity: passed through, it reaches the control plane as a truthy ICCID that
+        matches no line, so the SIM never falls through to the PC/SC bridge that can
+        still read it. Validated like the bridge's own decoder: 18-20 digits from 89.
+        """
+        text = str(value or "").strip()
+        if not text or text.casefold() in {"--", "unknown", "none", "n/a"}:
+            return ""
+        digits = re.sub(r"\D", "", text)
+        return digits if digits.startswith("89") and 18 <= len(digits) <= 20 else ""
+
+    @staticmethod
     def normalize_msisdn(value: str) -> str:
         """Return a conservative E.164-like number from ModemManager OwnNumbers.
 
@@ -1485,7 +1501,8 @@ class Orchestrator:
         if sim_object and sim_object not in {"--", "/"}:
             sim_detail = run(["mmcli", "-i", sim_object, "--output-keyvalue"])
             if sim_detail.returncode == 0:
-                sim_iccid = self._kv(sim_detail.stdout or "", "sim.properties.iccid")
+                sim_iccid = self.normalize_iccid(
+                    self._kv(sim_detail.stdout or "", "sim.properties.iccid"))
         # Many USB modems keep their hardware power-state at "on" after
         # ModemManager --disable.  The generic state is the authoritative RF state.
         radio_enabled = power == "on" and state not in {

--- a/host/mdd_orchestrator.py
+++ b/host/mdd_orchestrator.py
@@ -311,6 +311,10 @@ EXIT_RANK_WARMUP_SECONDS = float(os.environ.get("MDD_EXIT_RANK_WARMUP", "25"))
 # waking on the base interval to stat the input documents so an operator action is never
 # delayed by more than one base tick.
 IDLE_INTERVAL_SECONDS = float(os.environ.get("MDD_IDLE_INTERVAL", "15"))
+# A modem is plugged in so its SIM can be read; cellular data is a per-device capability, not
+# the box's route to the internet. Set this when the modem genuinely IS the only uplink.
+MODEM_MAY_PROVIDE_DEFAULT_ROUTE = os.environ.get(
+    "MDD_MODEM_ALLOW_DEFAULT_ROUTE", "").strip().lower() in {"1", "true", "yes", "on"}
 # How long a tty may stay unclaimed before the bridge stops waiting for ModemManager and talks
 # to the serial port itself. ModemManager needs on the order of ten to thirty seconds to probe
 # an EC25-class module, so this is set far beyond any healthy first pass: reaching it means
@@ -609,6 +613,10 @@ class Orchestrator:
         self.radio_states: dict[str, bool] = {}
         self.cellular_states: dict[str, dict] = {}
         self.data_attempt_at: dict[str, float] = {}
+        # Profiles already re-stamped with modem_profile_policy() this process. Correcting a
+        # legacy profile is a one-off; without this the data-off path would shell out to nmcli
+        # on every reconcile to rewrite settings that already say what we want.
+        self.modem_profile_policed: set[str] = set()
         self.applied_timezone = ""
         self.obsolete_services_retired = False
         self.reader_config_path = Path(os.environ.get(
@@ -1560,6 +1568,30 @@ class Orchestrator:
                     profiles.append((parts[0].replace(r"\:", ":"), parts[2]))
         return profiles
 
+    @staticmethod
+    def modem_profile_policy() -> list[str]:
+        """nmcli properties that keep a modem's data profile from becoming the host uplink.
+
+        Two separate things went wrong without them. The profile was created with autoconnect
+        on, so NetworkManager dialled it after a reboot however the operator had set this
+        modem's cellular-data switch -- the switch was silently not durable. And nothing
+        stopped the resulting connection from carrying the default route, which would send the
+        VoWiFi tunnel that authenticates this very SIM out through that SIM's own carrier.
+
+        Autoconnect stays off unconditionally: the orchestrator owns the desired state and
+        brings the profile up itself, so NetworkManager acting on its own can only contradict
+        the operator. The default-route guard is what MDD_MODEM_ALLOW_DEFAULT_ROUTE releases,
+        for a deployment whose only uplink really is the modem.
+        """
+        policy = ["connection.autoconnect", "no"]
+        if not MODEM_MAY_PROVIDE_DEFAULT_ROUTE:
+            # never-default is preventive where deleting the route afterwards is corrective:
+            # the route is never installed, so there is no window in which it is live and no
+            # repeated deletion of something already gone. It also reverses with one nmcli
+            # call, which matters on a box reached over the network it is about to reconfigure.
+            policy += ["ipv4.never-default", "yes", "ipv6.never-default", "yes"]
+        return policy
+
     def ensure_modem_data(self, modem: dict, snapshot: dict) -> None:
         """Give each modem its own NetworkManager GSM profile and bearer."""
         if not snapshot.get("powered") or snapshot.get("data_active"):
@@ -1582,8 +1614,8 @@ class Orchestrator:
         exists = run(["nmcli", "connection", "show", profile]).returncode == 0
         if not exists:
             command = ["nmcli", "connection", "add", "type", "gsm", "ifname", primary,
-                       "con-name", profile, "connection.autoconnect", "yes",
-                       "connection.autoconnect-retries", "0"]
+                       "con-name", profile, "connection.autoconnect-retries", "0",
+                       *self.modem_profile_policy()]
             if apn:
                 command.extend(["gsm.apn", apn, "gsm.auto-config", "no"])
             else:
@@ -1593,12 +1625,17 @@ class Orchestrator:
                 self.log(f"could not create cellular profile for {device_id}: "
                          f"{(result.stderr or result.stdout).strip()}")
                 return
-        elif apn:
-            # A profile may have been created before the retained bearer APN became visible.
-            result = run(["nmcli", "connection", "modify", profile,
-                          "gsm.apn", apn, "gsm.auto-config", "no"])
+        else:
+            # Re-stamped on every pass, not only at creation: profiles written by an older
+            # version carry autoconnect=yes and no default-route guard, and they outlive the
+            # upgrade. This is the only place that corrects them while data is wanted.
+            command = ["nmcli", "connection", "modify", profile, *self.modem_profile_policy()]
+            if apn:
+                # A profile may have been created before the retained bearer APN became visible.
+                command.extend(["gsm.apn", apn, "gsm.auto-config", "no"])
+            result = run(command)
             if result.returncode:
-                self.log(f"could not update cellular APN for {device_id}: "
+                self.log(f"could not update cellular profile for {device_id}: "
                          f"{(result.stderr or result.stdout).strip()}")
                 return
         result = run(["nmcli", "connection", "up", profile])
@@ -1607,9 +1644,25 @@ class Orchestrator:
                      f"{(result.stderr or result.stdout).strip()}")
 
     def disconnect_modem_data(self, snapshot: dict) -> None:
+        """Take this modem's data profile down and keep it down.
+
+        The profile is addressed by name rather than only by the port it is attached to. A
+        modem in a failed or SIM-less ModemManager state reports no primary port, so matching
+        on the port alone found nothing to do in exactly the state where an autoconnecting
+        profile is most likely to be dialling on its own.
+        """
+        profile = str(snapshot.get("profile") or "")
+        if profile and profile not in self.modem_profile_policed:
+            # Cellular data is off for this modem, so the profile must not come back by
+            # itself -- neither now nor after the next reboot. Once is enough: nothing else
+            # rewrites these properties behind us.
+            if run(["nmcli", "connection", "show", profile]).returncode == 0:
+                run(["nmcli", "connection", "modify", profile, *self.modem_profile_policy()])
+            self.modem_profile_policed.add(profile)
+        active = self._active_gsm_profiles()
         primary = snapshot.get("primary_port") or snapshot.get("network_interface")
-        for name, device in self._active_gsm_profiles():
-            if primary and device == primary:
+        for name, device in active:
+            if name == profile or (primary and device == primary):
                 run(["nmcli", "connection", "down", name])
 
     def apply_cellular_backend(self, enabled: bool, *, reset_modems: bool = True):

--- a/tests/test_device_state.py
+++ b/tests/test_device_state.py
@@ -363,6 +363,48 @@ bearer.stats.tx-bytes : 456
         self.assertEqual(len([c for c in calls if c[:3] == ["nmcli", "connection", "modify"]]), 1)
         self.assertLess(len(calls) - first, first * 5)
 
+    def _sweep(self, listing, returncode=0):
+        with tempfile.TemporaryDirectory() as temp:
+            app = Orchestrator(Path(temp) / "data", Path(temp), dry_run=False)
+            calls = []
+
+            def fake_run(args, **_kwargs):
+                calls.append(args)
+                if args[:2] == ["nmcli", "-t"]:
+                    return SimpleNamespace(returncode=returncode, stdout=listing, stderr="")
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+            with patch("host.mdd_orchestrator.run", side_effect=fake_run):
+                app.police_orphaned_modem_profiles()
+                app.police_orphaned_modem_profiles()
+            return calls, app
+
+    def test_a_leftover_profile_is_secured_when_cellular_is_simply_turned_off(self):
+        """Every data path is gated on the cellular backend being up, so turning cellular data
+        off -- ModemManager stood down, the GSM profile left behind -- is the one state where
+        nothing corrects a profile that still says autoconnect forever."""
+        listing = ("Wired connection 1:802-3-ethernet\n"
+                   "mdd-cell-0a05dad4d32d:gsm\n")
+        calls, app = self._sweep(listing)
+        modify = [call for call in calls if call[:3] == ["nmcli", "connection", "modify"]]
+        self.assertEqual(len(modify), 1, "swept once per stand-down, not per cycle")
+        self.assertEqual(modify[0][3], "mdd-cell-0a05dad4d32d")
+        self.assertEqual(modify[0][modify[0].index("connection.autoconnect") + 1], "no")
+        self.assertEqual(modify[0][modify[0].index("ipv4.never-default") + 1], "yes")
+        self.assertIn("mdd-cell-0a05dad4d32d", app.modem_profile_policed)
+
+    def test_the_sweep_leaves_connections_it_does_not_own_alone(self):
+        listing = ("Wired connection 1:802-3-ethernet\n"
+                   "some-other-modem:gsm\n"
+                   "mdd-cell-keep:bridge\n")
+        calls, _app = self._sweep(listing)
+        self.assertEqual([c for c in calls if c[:3] == ["nmcli", "connection", "modify"]], [])
+
+    def test_an_unreadable_connection_list_is_retried_rather_than_swallowed(self):
+        calls, app = self._sweep("", returncode=1)
+        self.assertFalse(app.modem_profiles_swept)
+        self.assertEqual(len([c for c in calls if c[:2] == ["nmcli", "-t"]]), 2)
+
     def test_unreadable_sim_iccid_is_not_reported_as_an_identity(self):
         """mmcli prints "--" for a property it could not read. Passed through, the control
         plane treats it as a live ICCID that matches no line and never falls through to the

--- a/tests/test_device_state.py
+++ b/tests/test_device_state.py
@@ -274,6 +274,95 @@ bearer.stats.tx-bytes : 456
             self.assertEqual(value["msisdn"], "+12025550100")
             self.assertEqual(value["sim_iccid"], "8901000000000000001")
 
+    def _orchestrator_calls(self, method, snapshot, *, exists=True, active=(), **kwargs):
+        with tempfile.TemporaryDirectory() as temp:
+            app = Orchestrator(Path(temp) / "data", Path(temp), dry_run=False)
+            calls = []
+
+            def fake_run(args, **_kwargs):
+                calls.append(args)
+                if args[:3] == ["nmcli", "connection", "show"] and len(args) == 4:
+                    return SimpleNamespace(returncode=0 if exists else 1, stdout="", stderr="")
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+            with patch.object(app, "_active_gsm_profiles", return_value=list(active)), patch(
+                    "host.mdd_orchestrator.run", side_effect=fake_run):
+                getattr(app, method)(snapshot, **kwargs) if method == "disconnect_modem_data" \
+                    else getattr(app, method)({"id": "modem-a"}, snapshot)
+            return calls, app
+
+    def test_a_modem_profile_never_autoconnects_or_carries_the_default_route(self):
+        """A modem is plugged in to have its SIM read. If NetworkManager dials it on its own
+        and the result becomes the default route, the VoWiFi tunnel authenticating that very
+        SIM leaves through that SIM's own carrier."""
+        policy = Orchestrator.modem_profile_policy()
+        self.assertEqual(policy[policy.index("connection.autoconnect") + 1], "no")
+        self.assertEqual(policy[policy.index("ipv4.never-default") + 1], "yes")
+        self.assertEqual(policy[policy.index("ipv6.never-default") + 1], "yes")
+
+    def test_the_default_route_guard_is_released_for_a_modem_only_uplink(self):
+        with patch.object(mdd_orchestrator, "MODEM_MAY_PROVIDE_DEFAULT_ROUTE", True):
+            policy = Orchestrator.modem_profile_policy()
+        # The switch is about the default route only: autoconnect stays off either way,
+        # because the orchestrator owns the desired state and brings the profile up itself.
+        self.assertEqual(policy[policy.index("connection.autoconnect") + 1], "no")
+        self.assertNotIn("ipv4.never-default", policy)
+        self.assertNotIn("ipv6.never-default", policy)
+
+    def test_a_new_cellular_profile_is_created_with_the_policy(self):
+        snapshot = {"powered": True, "data_active": False, "registration": "roaming",
+                    "primary_port": "ttyUSB5", "apn": "ims",
+                    "profile": Orchestrator.cellular_profile_name("modem-a")}
+        calls, _app = self._orchestrator_calls("ensure_modem_data", snapshot, exists=False)
+        add = next(call for call in calls if call[:3] == ["nmcli", "connection", "add"])
+        self.assertEqual(add[add.index("connection.autoconnect") + 1], "no")
+        self.assertEqual(add[add.index("ipv4.never-default") + 1], "yes")
+
+    def test_an_existing_legacy_profile_is_corrected_even_without_an_apn(self):
+        """Profiles written by an older version carry autoconnect=yes and no route guard, and
+        they outlive the upgrade. Correcting them only when an APN was known left them."""
+        snapshot = {"powered": True, "data_active": False, "registration": "home",
+                    "primary_port": "ttyUSB5", "apn": "",
+                    "profile": Orchestrator.cellular_profile_name("modem-a")}
+        calls, _app = self._orchestrator_calls("ensure_modem_data", snapshot, exists=True)
+        modify = next(call for call in calls if call[:3] == ["nmcli", "connection", "modify"])
+        self.assertEqual(modify[modify.index("connection.autoconnect") + 1], "no")
+        self.assertEqual(modify[modify.index("ipv4.never-default") + 1], "yes")
+
+    def test_disabling_data_reaches_a_profile_whose_modem_reports_no_port(self):
+        """A modem in a failed or SIM-less state reports no primary port. Matching only on the
+        port found nothing to do in exactly the state where an autoconnecting profile is most
+        likely to dial on its own."""
+        snapshot = {"profile": "mdd-cell-legacy", "primary_port": "", "network_interface": ""}
+        calls, app = self._orchestrator_calls(
+            "disconnect_modem_data", snapshot, active=[("mdd-cell-legacy", "wwan0")])
+        modify = next(call for call in calls if call[:3] == ["nmcli", "connection", "modify"])
+        self.assertEqual(modify[3], "mdd-cell-legacy")
+        self.assertEqual(modify[modify.index("connection.autoconnect") + 1], "no")
+        self.assertIn(["nmcli", "connection", "down", "mdd-cell-legacy"], calls)
+        self.assertIn("mdd-cell-legacy", app.modem_profile_policed)
+
+    def test_a_policed_profile_is_not_rewritten_on_every_reconcile(self):
+        """Data-off runs on every cycle. Rewriting settings that already say what we want was
+        the largest avoidable source of process creation in the old proposal for this fix."""
+        snapshot = {"profile": "mdd-cell-legacy", "primary_port": "", "network_interface": ""}
+        with tempfile.TemporaryDirectory() as temp:
+            app = Orchestrator(Path(temp) / "data", Path(temp), dry_run=False)
+            calls = []
+
+            def fake_run(args, **_kwargs):
+                calls.append(args)
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+            with patch.object(app, "_active_gsm_profiles", return_value=[]), patch(
+                    "host.mdd_orchestrator.run", side_effect=fake_run):
+                app.disconnect_modem_data(dict(snapshot))
+                first = len(calls)
+                for _ in range(5):
+                    app.disconnect_modem_data(dict(snapshot))
+        self.assertEqual(len([c for c in calls if c[:3] == ["nmcli", "connection", "modify"]]), 1)
+        self.assertLess(len(calls) - first, first * 5)
+
     def test_unreadable_sim_iccid_is_not_reported_as_an_identity(self):
         """mmcli prints "--" for a property it could not read. Passed through, the control
         plane treats it as a live ICCID that matches no line and never falls through to the

--- a/tests/test_device_state.py
+++ b/tests/test_device_state.py
@@ -274,6 +274,42 @@ bearer.stats.tx-bytes : 456
             self.assertEqual(value["msisdn"], "+12025550100")
             self.assertEqual(value["sim_iccid"], "8901000000000000001")
 
+    def test_unreadable_sim_iccid_is_not_reported_as_an_identity(self):
+        """mmcli prints "--" for a property it could not read. Passed through, the control
+        plane treats it as a live ICCID that matches no line and never falls through to the
+        PC/SC bridge, which can still read the card over a logical channel."""
+        self.assertEqual(Orchestrator.normalize_iccid("--"), "")
+        self.assertEqual(Orchestrator.normalize_iccid("unknown"), "")
+        self.assertEqual(Orchestrator.normalize_iccid(""), "")
+        self.assertEqual(Orchestrator.normalize_iccid("8901000000000000001"),
+                         "8901000000000000001")
+        # Not an ICCID: wrong issuer prefix, or too short to be one.
+        self.assertEqual(Orchestrator.normalize_iccid("1234567890123456789"), "")
+        self.assertEqual(Orchestrator.normalize_iccid("890100000"), "")
+
+    def test_snapshot_drops_a_placeholder_sim_iccid(self):
+        with tempfile.TemporaryDirectory() as temp:
+            app = Orchestrator(Path(temp) / "data", Path(temp), dry_run=False)
+            modem_detail = """modem.generic.primary-port : cdc-wdm1
+modem.generic.sim : /org/freedesktop/ModemManager1/SIM/1
+modem.generic.state : connected
+modem.generic.power-state : on
+"""
+
+            def fake_run(args, **_kwargs):
+                if args[:2] == ["mmcli", "-m"]:
+                    return SimpleNamespace(returncode=0, stdout=modem_detail, stderr="")
+                if args[:2] == ["mmcli", "-i"]:
+                    return SimpleNamespace(returncode=0,
+                                           stdout="sim.properties.iccid : --\n", stderr="")
+                return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+            with patch.object(app, "modemmanager_modem_for_tty",
+                              return_value="/org/freedesktop/ModemManager1/Modem/4"), patch(
+                                  "host.mdd_orchestrator.run", side_effect=fake_run):
+                value = app.modem_snapshot({"id": "modem-c", "tty": "/dev/ttyUSB7"})
+        self.assertEqual(value["sim_iccid"], "")
+
     def test_modem_number_normalization_rejects_placeholders_and_status_text(self):
         self.assertEqual(Orchestrator.normalize_msisdn("--"), "")
         self.assertEqual(Orchestrator.normalize_msisdn("not available"), "")

--- a/tests/test_modem_identity_metadata.py
+++ b/tests/test_modem_identity_metadata.py
@@ -1,0 +1,67 @@
+"""Bridge identity records must survive a modem that reports no IMEI.
+
+The VPCD bridge publishes an identity whose ``imei`` is empty whenever the module never
+answered the AT query -- it prints "imei=unavailable" and carries on, because the IMEI is
+not what identifies the modem (the hardware id in the reader name is). The control plane
+used to discard the whole record over that empty field and fall through to a synthetic
+``{"hardware_id": ..., "slots": 1}``, which took two things down with it: the bridge's
+ICCID, so the card never matched a line and the reader binding never migrated, and the
+slot count, so PIN/SWu/IMS collapsed onto a single VPCD reader.
+"""
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from control.app import main
+
+
+DEVICE_ID = "2c91-0002-000000000001"
+READER = f"VoWiFi Modem {DEVICE_ID} 00 00"
+ICCID = "8900000000000000001"
+IMEI = "350000000000006"
+
+
+class ModemIdentityMetadataTests(unittest.TestCase):
+    def _identity(self, **overrides):
+        record = {"hardware_id": DEVICE_ID, "imei": "", "iccid": ICCID, "slots": 3,
+                  "channel_allocated": 3, "channel_capacity": 3}
+        record.update(overrides)
+        with tempfile.TemporaryDirectory() as temp:
+            modems = Path(temp) / "modems"
+            modems.mkdir()
+            (modems / f"{DEVICE_ID}.json").write_text(json.dumps(record), encoding="utf-8")
+            with patch.object(main.cfg, "DATA_DIR", temp):
+                return main._modem_identity_for_reader(READER)
+
+    def test_identity_without_an_imei_keeps_its_iccid_and_slots(self):
+        identity = self._identity()
+        self.assertEqual(identity["hardware_id"], DEVICE_ID)
+        self.assertEqual(identity["iccid"], ICCID)
+        self.assertEqual(identity["slots"], 3)
+        self.assertEqual(identity["imei"], "")
+
+    def test_a_valid_imei_is_still_normalised_and_returned(self):
+        self.assertEqual(self._identity(imei=IMEI)["imei"], IMEI)
+
+    def test_an_unusable_imei_is_reported_as_absent_not_as_itself(self):
+        # Callers gate on a 15-digit IMEI; handing them a partial one would let it reach a
+        # line configuration as though the modem had really reported it.
+        for value in ("12345", "not-an-imei", None):
+            with self.subTest(value=value):
+                self.assertEqual(self._identity(imei=value)["imei"], "")
+
+    def test_an_unknown_reader_name_is_still_unidentified(self):
+        self.assertIsNone(main._modem_identity_for_reader("Some USB Reader 00 00"))
+
+    def test_a_modem_with_no_published_record_keeps_the_offline_fallback(self):
+        with tempfile.TemporaryDirectory() as temp:
+            (Path(temp) / "modems").mkdir()
+            with patch.object(main.cfg, "DATA_DIR", temp):
+                identity = main._modem_identity_for_reader(READER)
+        self.assertEqual(identity, {"hardware_id": DEVICE_ID, "slots": 1})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Four fixes to the modem paths, found while reviewing PR #74 against the current code. Each was confirmed in our own tree first; none of them is specific to the module that PR was written for.

**A SIM whose ICCID could not be read is now unidentified, not misidentified.** `mmcli` renders an unreadable property as the literal `--`, and `sim.properties.iccid` was the one field not normalised against that placeholder — `modem.3gpp.operator-name` and OwnNumbers beside it already were. It reached the control plane as a truthy ICCID that matched no line, so the SIM never fell through to the PC/SC bridge that can still read it.

**A modem that reports no IMEI keeps its bridge identity.** The bridge publishes an identity with an empty `imei` on purpose (it logs `imei=unavailable` and carries on). The control plane discarded the whole record over that field, which also dropped the bridge's ICCID — so the card matched no line and the reader binding never migrated — and collapsed the modem to a one-slot fallback, putting PIN, SWu and IMS on a single VPCD reader.

**A modem's data profile no longer autoconnects or offers a default route.** NetworkManager dialled the profile after a reboot however the operator had set that modem's cellular-data switch, and nothing stopped the result from carrying the default route — which would send the VoWiFi tunnel authenticating that very SIM out through the SIM's own carrier. `ipv4/ipv6.never-default` is preventive where deleting the route afterwards is corrective: the route is never installed, nothing has to be re-deleted every cycle, and it reverses with one nmcli call. `MDD_MODEM_ALLOW_DEFAULT_ROUTE=1` releases the guard where the modem really is the only uplink; autoconnect stays off either way, because the orchestrator owns the desired state.

**A leftover profile is secured even when cellular data is simply switched off.** Every data path is gated on `through_modemmanager`, so backend-down was the one state in which nothing corrected a profile that still said autoconnect forever — the worst place to leave it.

## Test plan

- [x] 1076 unittest pass; privacy scan clean
- [x] **Verified on the Pi.** It has a real leftover `mdd-cell-*` profile reading `autoconnect: yes, autoconnect-retries: 0 (forever)`, with cellular disabled and ModemManager down — which is how the fourth fix was found: the third one never runs in that state. Reset the profile to the broken state, ran the sweep: found, secured, persisted to the keyfile, logged once, repeat call a no-op. Other connections, both default routes and the three running lines untouched; no service restarted.
- [ ] Not verified on hardware: the failed/SIM-less disconnect path (needs ModemManager running, which would contend for the EC25's serial ports) and an actual default-route takeover (needs an RNDIS-class modem). Unit tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
