### PR TITLE
fix(ami): close a manager whose connect was refused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@ All notable changes follow Keep a Changelog and Semantic Versioning.
 
 ## [Unreleased]
 
-## [1.9.2] - 2026-09-08
-
 ### Fixed
 
+- An AMI connection that was refused no longer leaves its manager pinging a transport that
+  never opened. panoramisk schedules a pinger and a reconnect timer as soon as a manager is
+  created and the event loop keeps the object alive through them, so a failed connect logged
+  a send failure once per ping interval for as long as the control plane ran. Restarting the
+  control plane while the engine containers are still starting -- what an upgrade does --
+  was enough to trigger it.
 - Cellular SMS and calls can match a line by IMSI when ModemManager cannot read that SIM's
   ICCID. A readable but different ICCID still fails closed instead of falling back to IMSI.
 - ML307X VoWiFi lines keep their allocated PIN, SWu and IMS reader slots across profile
@@ -16,6 +20,11 @@ All notable changes follow Keep a Changelog and Semantic Versioning.
   no longer calls an undefined helper, and now goes through the shared APDU exchange, so a
   TPDU-level reader's `61xx` response is fetched rather than left pending for the next
   command ([#74](https://github.com/MddIdd/mdd-sim-gateway/pull/74)).
+
+## [1.9.2] - 2026-09-08
+
+### Fixed
+
 - Missing tunnel evidence and local DNS, SIM, protocol or engine failures no longer count as
   failed exit nodes. Unknown evidence does not trigger node changes or stalled-session cleanup,
   and notifications no longer claim a clean tunnel when that has not been established.

--- a/control/app/ami.py
+++ b/control/app/ami.py
@@ -63,6 +63,24 @@ class AmiClient:
             self._connected = True
             log.info("AMI connected instance=%s %s:%s", self.instance_id, self.host, self.port)
         except Exception as e:  # noqa  (asyncio.TimeoutError included)
+            # A Manager whose connect failed is not inert. panoramisk has already scheduled
+            # its pinger and its reconnect timer on the event loop, and those callbacks keep
+            # the object reachable, so nothing collects it. ami_for() caches this client and
+            # drops it on its next pass -- but until some caller asks for this instance again
+            # the Manager keeps sending Ping on a transport that never opened, once per ping
+            # interval, for as long as the control plane lives. Observed after an upgrade
+            # restarted the control plane while the engine containers were still starting:
+            # one refused connect left ~5 log lines a minute for hours.
+            #
+            # The failure path owns its own cleanup instead. Closing here cannot lose a
+            # connection that would otherwise have recovered: _connected is only ever set by
+            # a successful connect(), so a Manager that reconnects behind our back still
+            # leaves this client unusable and ami_for() rebuilds it either way.
+            self._closed = True
+            try:
+                self._mgr.close()
+            except Exception:
+                pass
             self._connected = False
             log.warning("AMI connect failed instance=%s: %r", self.instance_id, e)
 

--- a/tests/test_status_registration.py
+++ b/tests/test_status_registration.py
@@ -1,6 +1,7 @@
+import asyncio
 import unittest
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from control.app.ami import AmiClient
 from control.app import status
@@ -148,6 +149,46 @@ class AmiRegistrationTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(await client.active_channel_count(), 2)
         client._action.assert_awaited_once_with(
             {"Action": "Command", "Command": "core show channels count"}, timeout=3.0)
+
+    async def test_a_refused_connect_closes_its_manager(self):
+        """panoramisk schedules a pinger and a reconnect timer as soon as a Manager is
+        created, and the event loop keeps the object alive through them. A Manager left
+        open by a failed connect pings a transport that never opened, once per interval,
+        for as long as the control plane lives -- observed for hours after an upgrade
+        restarted the control plane while the engine containers were still starting."""
+        manager = MagicMock()
+        manager.connect = AsyncMock(side_effect=ConnectionRefusedError(111, "Connection refused"))
+        client = AmiClient("1", "172.17.0.2", 5038, "user", "secret", "realm")
+        with patch("control.app.ami.Manager", return_value=manager):
+            await client.connect()
+
+        manager.close.assert_called_once()
+        self.assertFalse(client.connected)
+
+    async def test_a_timed_out_connect_also_closes_its_manager(self):
+        manager = MagicMock()
+
+        async def _never(*_a, **_k):
+            await asyncio.sleep(3600)
+
+        manager.connect = _never
+        client = AmiClient("1", "172.17.0.2", 5038, "user", "secret", "realm")
+        with patch("control.app.ami.Manager", return_value=manager), \
+                patch.object(AmiClient, "CONNECT_TIMEOUT", 0.01):
+            await client.connect()
+
+        manager.close.assert_called_once()
+        self.assertFalse(client.connected)
+
+    async def test_a_successful_connect_keeps_its_manager_open(self):
+        manager = MagicMock()
+        manager.connect = AsyncMock(return_value=None)
+        client = AmiClient("1", "172.17.0.2", 5038, "user", "secret", "realm")
+        with patch("control.app.ami.Manager", return_value=manager):
+            await client.connect()
+
+        manager.close.assert_not_called()
+        self.assertTrue(client.connected)
 
     async def test_unreadable_active_channel_count_fails_closed(self):
         client = AmiClient("1", "172.17.0.2", 5038, "user", "secret", "realm")


### PR DESCRIPTION
## Summary

Found while verifying v1.9.2 on the Pi. The control plane was logging an AMI send failure every ten seconds — 516 of them over 100 minutes, all `Ping`, all carrying a single manager's action id, still going.

panoramisk schedules a pinger and a reconnect timer as soon as a `Manager` exists, and those callbacks keep the object reachable, so nothing collects it. `connect()` left the manager open on failure and only cleared `_connected`. `ami_for()` caches the client and drops it on its next pass, but until some caller asks for that instance again the manager keeps pinging a transport that never opened, for the life of the process. One refused connect to instance 1 at 16:44:53 was still producing log lines at 18:11.

Restarting the control plane while the engine containers are still starting is enough to reach it — which is what an upgrade does.

**Not a v1.9.2 regression.** `control/app/ami.py` is unchanged since before v1.9.1; the upgrade only supplied the restart that exposed it. Impact was log noise (~7k lines/day) and one wedged timer, not an outage: all three lines were Registered throughout and every AMI port was reachable.

Closing on the failure path cannot lose a connection that would otherwise have recovered — `_connected` is set only by a successful `connect()`, so a manager that reconnects behind our back leaves the client unusable either way and `ami_for()` rebuilds it.

## Also

Moves the #74 changelog entries out of the released `[1.9.2]` section. That branch was rebased onto `develop` after the tag was pushed, so its entries landed under a version that does not contain them. The `[1.9.2]` section now matches `git show v1.9.2:CHANGELOG.md` word for word.

## Test plan

- [x] Three regression tests: a refused connect and a timed-out connect both close the manager; a successful connect does not
- [x] Verified the new tests fail against the unfixed `ami.py` and pass with it — not vacuous
- [x] Full suite 1098 pass; privacy scan clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
