### PR TITLE
fix: pass SWU_TUN_MTU to managed engine containers

### DIFF
--- a/control/app/engine.py
+++ b/control/app/engine.py
@@ -467,6 +467,7 @@ def start(inst: dict, settings: dict, dev_mounts: bool = False, reason: str = "r
         environment={
             "MDD_ID": iid,
             "SWU_LIVENESS_PERIOD": str(inst.get("liveness_period", 0)),
+            "SWU_TUN_MTU": os.environ.get("SWU_TUN_MTU", "1400"),
         },
         sysctls={
             "net.ipv6.conf.all.accept_ra": "0",


### PR DESCRIPTION
## Summary

## Safety and privacy impact

- [ ] No real SIM identity, phone number, PIN, token, subscription URL, message or call data is included.
- [ ] Device-changing operations fail closed and report actual state.
- [ ] User-visible changes are documented.
- [ ] Python tests and WebUI build pass.


Pass `SWU_TUN_MTU` from the control service environment to managed engine containers, retaining the default value of `1400`.

The tunnel implementation already supports this variable, but the control service does not forward it when creating containers. Operators currently need a custom image or a code change to configure the tunnel MTU.

With this change, native deployments can configure a systemd override:

```ini
[Service]
Environment=SWU_TUN_MTU=1280
```

The control service must be restarted and the engine container recreated for the setting to take effect.

## Validation

The operational results above were obtained with an environment-only derived image. The environment-forwarding change should additionally be verified to pass:

- `1400` when the control service variable is unset.
- `1280` when the control service variable is set to `1280`.