### PR TITLE
fix: install mobile broadband provider database

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -213,9 +213,9 @@ ensure_xray() {
 }
 
 ensure_cellular_tools() {
-  if have apt-get; then pkg_install modemmanager network-manager dbus
-  elif have dnf || have yum; then pkg_install ModemManager NetworkManager dbus
-  elif have pacman; then pkg_install modemmanager networkmanager dbus
+  if have apt-get; then pkg_install modemmanager network-manager mobile-broadband-provider-info dbus
+  elif have dnf || have yum; then pkg_install ModemManager NetworkManager mobile-broadband-provider-info dbus
+  elif have pacman; then pkg_install modemmanager networkmanager mobile-broadband-provider-info dbus
   fi
   have mmcli || die "ModemManager command mmcli is unavailable"
   have nmcli || die "NetworkManager command nmcli is unavailable"


### PR DESCRIPTION
## Summary

## Safety and privacy impact

- [ ] No real SIM identity, phone number, PIN, token, subscription URL, message or call data is included.
- [ ] Device-changing operations fail closed and report actual state.
- [ ] User-visible changes are documented.
- [ ] Python tests and WebUI build pass.

Add mobile-broadband-provider-info to the apt, dnf/yum, and pacman dependency lists.

Without this package, NetworkManager's automatic APN selection can fail with APN not found, even when the modem is registered on LTE.

Tested on Debian: installing the package fixed the connection, HTTPS over 4G worked, and automatic reconnection succeeded. Other distributions have not been tested.