### PR TITLE
feat(ims): let a line present its own SIP User-Agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes follow Keep a Changelog and Semantic Versioning.
 
 ## [Unreleased]
 
+### Added
+
+- A line can present its own SIP User-Agent, set under Advanced IMS identity. Carriers that
+  gate IMS registration on a terminal whitelist answer 403 to an unrecognised User-Agent, and
+  configuring the IMEI does not help -- that value only reaches the ePDG's DEVICE_IDENTITY.
+  Left empty a line still identifies as `MDD-Sim-Gateway`. The value is rendered into
+  `pjsip.conf`, so it is reduced to a single line of printable ASCII and capped at 64
+  characters ([#83](https://github.com/MddIdd/mdd-sim-gateway/issues/83)).
+
 ## [1.9.3] - 2026-09-11
 
 ### Fixed

--- a/control/app/config.py
+++ b/control/app/config.py
@@ -29,6 +29,13 @@ _lock = threading.RLock()
 # deployment configuration.
 MAX_SIM_LINES = 5
 
+# SIP User-Agent a line presents to the IMS core. The product identifies itself honestly by
+# default; a line may override it because some carriers gate IMS registration on a User-Agent
+# whitelist and answer 403 to anything they do not recognise (issue #83). The cap keeps the
+# header inside what a P-CSCF will accept.
+DEFAULT_USER_AGENT = "MDD-Sim-Gateway"
+MAX_USER_AGENT_LEN = 64
+
 
 class LineLimitError(ValueError):
     pass
@@ -779,6 +786,12 @@ def _upsert_instance_locked(inst: dict, unique_name: bool = False) -> dict:
     # Ignore stale clients and hand-written API requests that try to restore remote SIP
     # accounts. Only the authenticated browser softphone endpoint is rendered.
     sip["external"] = []
+    # Normalise the User-Agent on the way in so the saved line reads back exactly what it
+    # presents to the carrier; sanitising only at render time would show the operator text
+    # that pjsip.conf never receives. render_instance_json sanitises again for configs that
+    # were hand-edited rather than saved through here.
+    if "user_agent" in sip:
+        sip["user_agent"] = sanitize_user_agent(sip.get("user_agent"))
     wr = sip.setdefault("webrtc", {})
     wr.setdefault("username", "webrtc")
     if not wr.get("password"):
@@ -869,6 +882,21 @@ def card_auto_create_suppressed(iccid: str) -> bool:
 def normalize_imei(imei: str) -> str:
     """Strip any formatting (dashes/spaces) from an IMEI and return just the digits."""
     return "".join(ch for ch in (imei or "") if ch.isdigit())
+
+
+def sanitize_user_agent(value: str) -> str:
+    """Return a single-line SIP User-Agent, or '' meaning "use DEFAULT_USER_AGENT".
+
+    The value lands verbatim in pjsip.conf's ``[global] user_agent``, so a newline would let a
+    saved line append arbitrary Asterisk configuration. Everything outside printable ASCII
+    becomes a space and runs of whitespace collapse, which also disposes of CR/LF and tabs.
+    ';' goes the same way: Asterisk starts a comment there, so keeping it would silently
+    truncate the header at render time instead of at the point the operator typed it.
+    Mirrored by engine/render.py for hand-authored instance.json files.
+    """
+    cleaned = "".join(ch if " " <= ch <= "~" and ch != ";" else " "
+                      for ch in str(value or ""))
+    return " ".join(cleaned.split())[:MAX_USER_AGENT_LEN].strip()
 
 
 def imeisv_from_imei(imei: str, imeisv: str = "", svn: str = "00") -> str:
@@ -1108,9 +1136,10 @@ def render_instance_json(inst: dict, settings: dict) -> dict:
                 sip.get("vm_ring_seconds") or settings.get("vm_ring_seconds", 25)))),
             "vm_max_seconds": max(30, min(300, int(
                 sip.get("vm_max_seconds") or settings.get("vm_max_seconds", 120)))),
-            # Public builds identify themselves honestly; stale/manual settings cannot make
-            # the gateway impersonate a handset model.
-            "user_agent": "MDD-Sim-Gateway",
+            # Honest product identity unless the line explicitly overrides it: carriers that
+            # gate IMS registration on a User-Agent whitelist reject the default with 403, and
+            # the operator running that SIM is the one who can tell. Blank = default.
+            "user_agent": sanitize_user_agent(sip.get("user_agent")) or DEFAULT_USER_AGENT,
             # Some IMS cores require telephone-number request URIs to carry ;user=phone before
             # they will route an originating voice INVITE. Keep this carrier-configurable because
             # other networks reject SMS MESSAGE request URIs when the parameter is present.

--- a/engine/render.py
+++ b/engine/render.py
@@ -112,6 +112,23 @@ def imeisv_from_imei(imei, imeisv="", svn="00"):
     return base14 + svn2
 
 
+DEFAULT_USER_AGENT = "MDD-Sim-Gateway"
+MAX_USER_AGENT_LEN = 64
+
+
+def sanitize_user_agent(value):
+    """Return a single-line SIP User-Agent, or '' meaning "use DEFAULT_USER_AGENT".
+
+    Mirrors control/app/config.sanitize_user_agent so a hand-authored instance.json cannot put
+    a newline (and with it arbitrary Asterisk configuration) into pjsip.conf's [global]
+    user_agent. ';' is dropped for the same reason it is there: Asterisk reads it as the start
+    of a comment.
+    """
+    cleaned = "".join(ch if " " <= ch <= "~" and ch != ";" else " "
+                      for ch in str(value or ""))
+    return " ".join(cleaned.split())[:MAX_USER_AGENT_LEN].strip()
+
+
 def build_context(cfg):
     mcc = str(cfg["mcc"])
     mnc = str(cfg["mnc"]).zfill(3)
@@ -171,8 +188,9 @@ def build_context(cfg):
         # carrier P-CSCF augments this; a bogus value can make some SMSCs reject MO SMS.
         "pani": (sip.get("pani") or r"IEEE-802.11\;i-wlan-node-id=ffffffffffff"),
         "access_type": (sip.get("access_type") or ""),
-        # Use a transparent product identity rather than impersonating a phone.
-        "user_agent": "MDD-Sim-Gateway",
+        # Transparent product identity unless the line overrides it (carrier User-Agent
+        # whitelists answer 403 to an unknown terminal). Blank/unset keeps the default.
+        "user_agent": sanitize_user_agent(sip.get("user_agent")) or DEFAULT_USER_AGENT,
         "user_eq_phone": bool(sip.get("user_eq_phone", False)),
         # SDP identity (s=/o= lines) — Asterisk defaults s=Asterisk which fingerprints it.
         "sdp_session": (sip.get("sdp_session") or "-"),

--- a/tests/test_line_user_agent.py
+++ b/tests/test_line_user_agent.py
@@ -1,0 +1,150 @@
+"""A line may present its own SIP User-Agent (issue #83).
+
+Some carriers gate IMS registration on a User-Agent whitelist and answer 403 to a terminal
+they do not recognise, which no amount of IMEI configuration fixes -- the IMEI only reaches
+the ePDG's DEVICE_IDENTITY. The value is rendered verbatim into pjsip.conf's [global]
+user_agent, so the tests that matter here are the ones proving a saved line cannot use it to
+write additional Asterisk configuration.
+"""
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from control.app import config
+
+
+def engine_render():
+    """Load engine/render.py the way tests/test_engine_paths.py does (it is not a package)."""
+    root = Path(__file__).resolve().parent.parent
+    spec = importlib.util.spec_from_file_location(
+        "mdd_render_ua", root / "engine" / "render.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def instance(**sip) -> dict:
+    return {
+        "id": "3", "index": 0, "imsi": "001010000000000",
+        "mcc": "001", "mnc": "01", "iccid": "test-card",
+        "imei": "490154203237518", "ami_secret": "test-secret",
+        "sip": {"webrtc": {"enable": True, "password": "test-password"}, **sip},
+    }
+
+
+class RenderedUserAgentTests(unittest.TestCase):
+    def test_a_line_without_an_override_still_identifies_as_the_product(self):
+        rendered = config.render_instance_json(instance(), {})
+
+        self.assertEqual(rendered["sip"]["user_agent"], "MDD-Sim-Gateway")
+
+    def test_an_explicit_user_agent_reaches_the_engine(self):
+        rendered = config.render_instance_json(
+            instance(user_agent="SM-G975F Build/QP1A.190711.020"), {})
+
+        self.assertEqual(rendered["sip"]["user_agent"],
+                         "SM-G975F Build/QP1A.190711.020")
+
+    def test_a_blank_override_falls_back_instead_of_emptying_the_header(self):
+        # An empty user_agent= in pjsip.conf is not "no override", it is a line that registers
+        # without identifying itself at all.
+        rendered = config.render_instance_json(instance(user_agent="   "), {})
+
+        self.assertEqual(rendered["sip"]["user_agent"], "MDD-Sim-Gateway")
+
+
+class UserAgentSanitisingTests(unittest.TestCase):
+    """Both sanitisers must agree: the control plane writes instance.json, but a
+    hand-authored one reaches the same template through engine/render.py."""
+
+    def sanitisers(self):
+        return (("control", config.sanitize_user_agent),
+                ("engine", engine_render().sanitize_user_agent))
+
+    def test_a_newline_cannot_append_asterisk_configuration(self):
+        attack = "Phone/1.0\nuser_agent=evil\n[volte_ims]\ntype=endpoint"
+
+        for name, sanitize in self.sanitisers():
+            with self.subTest(name):
+                cleaned = sanitize(attack)
+                self.assertNotIn("\n", cleaned)
+                self.assertEqual(cleaned, "Phone/1.0 user_agent=evil [volte_ims] type=endpoint")
+
+    def test_a_semicolon_cannot_comment_out_the_rest_of_the_line(self):
+        for name, sanitize in self.sanitisers():
+            with self.subTest(name):
+                self.assertEqual(sanitize("Phone/1.0;evil=yes"), "Phone/1.0 evil=yes")
+
+    def test_control_characters_and_padding_are_dropped(self):
+        for name, sanitize in self.sanitisers():
+            with self.subTest(name):
+                self.assertEqual(sanitize("  Phone\t/\r1.0\x00  "), "Phone / 1.0")
+
+    def test_an_absurd_value_is_capped(self):
+        for name, sanitize in self.sanitisers():
+            with self.subTest(name):
+                cleaned = sanitize("A" * 500)
+                self.assertEqual(len(cleaned), 64)
+                self.assertFalse(cleaned.endswith(" "))
+
+    def test_nothing_usable_means_use_the_default(self):
+        for name, sanitize in self.sanitisers():
+            with self.subTest(name):
+                self.assertEqual(sanitize(None), "")
+                self.assertEqual(sanitize("\n\t"), "")
+
+
+class SavedLineTests(unittest.TestCase):
+    def setUp(self):
+        self._temp = tempfile.TemporaryDirectory()
+        root = self._temp.name
+        self._patch = patch.multiple(config, DATA_DIR=root,
+                                     CONFIG_PATH=str(Path(root) / "config.yaml"))
+        self._patch.start()
+        self.addCleanup(self._temp.cleanup)
+        self.addCleanup(self._patch.stop)
+
+    def test_the_stored_value_is_what_the_line_will_present(self):
+        # Sanitising only at render time would leave the WebUI showing text that pjsip.conf
+        # never receives, with no hint that it had been rewritten.
+        saved = config.upsert_instance({
+            "id": "1", "imsi": "001010000000000",
+            "sip": {"user_agent": " Phone/1.0;evil \n"},
+        })
+
+        self.assertEqual(saved["sip"]["user_agent"], "Phone/1.0 evil")
+
+    def test_saving_an_unrelated_field_does_not_invent_a_user_agent(self):
+        saved = config.upsert_instance({"id": "1", "imsi": "001010000000000",
+                                        "sip": {"listen_addr": "0.0.0.0"}})
+
+        self.assertNotIn("user_agent", saved["sip"])
+
+
+class EngineFallbackTests(unittest.TestCase):
+    def test_a_hand_authored_instance_json_without_a_user_agent_gets_the_default(self):
+        render = engine_render()
+        ctx = render.build_context({
+            "id": "3", "imsi": "001010000000000", "mcc": "001", "mnc": "01",
+            "ami_secret": "test-secret", "local_addr": "172.17.0.2",
+            "sip": {"webrtc": {"enable": True, "password": "test-password"}},
+        })
+
+        self.assertEqual(ctx["user_agent"], "MDD-Sim-Gateway")
+
+    def test_the_engine_honours_and_sanitises_an_override(self):
+        render = engine_render()
+        ctx = render.build_context({
+            "id": "3", "imsi": "001010000000000", "mcc": "001", "mnc": "01",
+            "ami_secret": "test-secret", "local_addr": "172.17.0.2",
+            "sip": {"webrtc": {"enable": True, "password": "test-password"},
+                    "user_agent": "Phone/1.0\nbind=0.0.0.0"},
+        })
+
+        self.assertEqual(ctx["user_agent"], "Phone/1.0 bind=0.0.0.0")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webui/src/i18n.jsx
+++ b/webui/src/i18n.jsx
@@ -194,6 +194,7 @@ const zh = {
   'Two-letter ISO code. Leave blank to select the exit from the SIM MCC.': '两位 ISO 国家代码。留空时根据 SIM MCC 自动选择出口。',
   'IMEISV — optional': 'IMEISV（可选）', 'SMS centre (SMSC)': '短信中心（SMSC）', 'Auto (from SIM)': '自动（从 SIM 读取）', Manual: '手动',
   'Device User-Agent (how the line identifies to the carrier)': '设备 User-Agent（线路向运营商报告的设备身份）',
+  'Leave empty to identify as MDD-Sim-Gateway. Set this only when the carrier rejects registration from an unrecognised terminal.': '留空则以 MDD-Sim-Gateway 身份标识。仅当运营商拒绝未知终端注册时才需要填写。',
   'Advanced IMS identity': '高级 IMS 身份',
   'Carrier defaults are applied automatically. Change these fields only when required by the carrier.': '系统会自动应用运营商默认值；仅在运营商明确要求时修改这些字段。',
   'Automatic carrier default': '自动使用运营商默认值', 'IMS access type': 'IMS 接入类型',

--- a/webui/src/views/SimConfig.jsx
+++ b/webui/src/views/SimConfig.jsx
@@ -410,6 +410,14 @@ export default function SimConfig({ instances, selected, refresh, cards, setSele
                 placeholder={t('Automatic carrier default')} />
             </Field>
           </div>
+          <Field label={t('Device User-Agent (how the line identifies to the carrier)')}>
+            <input className="mono" maxLength={64} value={form.sip.user_agent || ''}
+              onChange={(e) => updSip({ user_agent: e.target.value })}
+              placeholder="MDD-Sim-Gateway" />
+            <div style={{ fontSize: 11, color: 'var(--text-mute)', marginTop: 2 }}>
+              {t('Leave empty to identify as MDD-Sim-Gateway. Set this only when the carrier rejects registration from an unrecognised terminal.')}
+            </div>
+          </Field>
           <label style={{ marginTop: 8 }}>
             <input type="checkbox" style={{ width: 'auto', marginRight: 8 }} checked={!!form.sip.user_eq_phone}
               onChange={(e) => updSip({ user_eq_phone: e.target.checked })} />


### PR DESCRIPTION
Closes #83.

Some carriers gate IMS registration on a User-Agent whitelist and answer 403 to a terminal
they do not recognise. Configuring the IMEI does not help: that value only reaches the
ePDG's `DEVICE_IDENTITY`, while the SIP User-Agent was hardcoded in both the control plane
and the engine, so an affected line had no way to register.

A line may now override it under Advanced IMS identity; left empty it still identifies as
`MDD-Sim-Gateway`, so the default is unchanged for every existing line.

The value is rendered verbatim into `pjsip.conf`'s `[global] user_agent`, so it is reduced
to a single line of printable ASCII and capped at 64 characters -- a newline would otherwise
let a saved line append arbitrary Asterisk configuration, and `;` would silently truncate the
header at render time. The sanitiser runs on save, so the stored line reads back exactly what
it presents, and again at render time for a hand-authored `instance.json`.

## Verification

`tests/test_line_user_agent.py` (12 tests) plus the full suite: 1116 tests pass.

Note that 7 of those 12 tests cannot even be collected without `jinja2` installed --
`engine/render.py` imports it at module level. Run the suite against
`control/requirements.txt`, not a bare interpreter, or the engine-side rendering of this
feature goes silently unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)