### PR TITLE
fix(cellular): stop importing mmcli's placeholder and consume MMS notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes follow Keep a Changelog and Semantic Versioning.
 
 ## [Unreleased]
 
+### Fixed
+
+- A multi-part SMS is no longer imported twice, the first copy reading `--`. `mmcli` renders
+  the still-unassembled text of a multi-part message as its placeholder `--`, and the receive
+  scanner stored that as a body; when the remaining parts arrived the assembled text was
+  imported again as a separate message, because the import fingerprint covers the body. The
+  placeholder and ModemManager's `receiving` state now both count as "no readable text yet"
+  ([#84](https://github.com/MddIdd/mdd-sim-gateway/issues/84)).
+- A carrier MMS notification is deleted from ModemManager instead of holding modem/SIM SMS
+  storage indefinitely. It arrives on the SMS channel as a WAP Push carrying no readable text
+  and a binary WSP payload, so a gateway that never retrieves MMS can neither show nor forward
+  it and nothing else ever consumes it; on a SIM that receives them regularly the storage
+  eventually fills and no new SMS can arrive. Recognition requires both an unreadable text and
+  the standard `application/vnd.wap.mms-message` marker, so it keys on no carrier's sender
+  number, SMSC or MMSC host. Set `drop_mms_wap_push: false` under `settings` to keep the raw
+  objects ([#85](https://github.com/MddIdd/mdd-sim-gateway/issues/85)).
+
 ## [1.9.3] - 2026-09-11
 
 ### Fixed

--- a/control/app/cellular_sms.py
+++ b/control/app/cellular_sms.py
@@ -125,6 +125,57 @@ def _normalize_iccid(value) -> str:
     return "" if text == "--" else text
 
 
+def _sms_text(value) -> str:
+    """Return the readable body of an SMS, or empty when ModemManager has none yet.
+
+    mmcli renders an unreadable property as the literal placeholder "--", and the text of a
+    multi-part SMS stays unreadable until every part has arrived. Storing that placeholder
+    would both show "--" as a message and, once assembly completes, import the real text as a
+    second message, because the import fingerprint covers the body. A genuine one-character
+    body of "--" is indistinguishable here and is dropped with it; that is far rarer than an
+    incomplete multi-part SMS, which is a routine event on every long message.
+    """
+    text = str(value or "")
+    return "" if text.strip() == "--" else text
+
+
+# A carrier MMS notification is delivered over the SMS channel as a WAP Push with no readable
+# text and a binary WSP payload carrying this MIME type. The marker is the standard one from
+# WAP-209-MMSEncapsulation, so it identifies the notification for any carrier without keying
+# on a sender number, an SMSC or an MMSC host.
+_WAP_PUSH_MMS_MARKER = b"application/vnd.wap.mms-message"
+# Give up after a few failures so an object that can never be deleted (a read-only storage, a
+# revoked permission) does not put an mmcli call into every five-second poll forever.
+_WAP_PUSH_DELETE_ATTEMPTS = 3
+
+
+def _sms_data(value) -> bytes:
+    """Decode the mmcli rendering of an SMS binary payload; empty when absent or unparsable."""
+    if isinstance(value, (list, tuple)):
+        try:
+            return bytes(int(item) & 0xFF for item in value)
+        except (TypeError, ValueError):
+            return b""
+    text = str(value or "").strip()
+    if not text or text == "--":
+        return b""
+    # mmcli prints the payload as space-separated hex bytes; tolerate other byte separators.
+    compact = re.sub(r"[^0-9A-Fa-f]", "", text)
+    if not compact or len(compact) % 2:
+        return b""
+    try:
+        return bytes.fromhex(compact)
+    except ValueError:
+        return b""
+
+
+def _is_mms_wap_push(content: dict) -> bool:
+    """True for a binary MMS notification: no readable text plus the WAP Push MIME marker."""
+    if _sms_text(content.get("text")).strip():
+        return False
+    return _WAP_PUSH_MMS_MARKER in _sms_data(content.get("data"))
+
+
 def _normalize_imsi(value) -> str:
     """Return the digits-only comparison form of an IMSI, or empty when absent."""
     return re.sub(r"\D", "", str(value or ""))
@@ -455,18 +506,33 @@ class Scanner:
 
     def __init__(self, runner=subprocess.run, *, topology_ttl: float = 60.0,
                  detail_ttl: float = 60.0, clock=time.monotonic,
-                 local_sms_tracker=None, epoch_getter=_modemmanager_epoch):
+                 local_sms_tracker=None, epoch_getter=_modemmanager_epoch,
+                 drop_mms_wap_push: bool = True):
         self.runner = runner
         self.topology_ttl = topology_ttl
         self.detail_ttl = detail_ttl
         self.clock = clock
         self.local_sms_tracker = local_sms_tracker
         self.epoch_getter = epoch_getter
+        self.drop_mms_wap_push = drop_mms_wap_push
         self._daemon_epoch = ""
         self._topology_expires = 0.0
         self._topology: list[tuple[str, str]] = []
         self._details: dict[tuple[str, str], tuple[float, dict]] = {}
         self._local_sms_keys: OrderedDict[tuple[str, str, str], None] = OrderedDict()
+        self._wap_push_attempts: dict[tuple[str, str], int] = {}
+
+    def _consume_mms_wap_push(self, key: tuple[str, str], modem_path: str,
+                              sms_path: str) -> None:
+        """Delete one recognised MMS notification so modem/SIM storage cannot fill up."""
+        attempts = self._wap_push_attempts.get(key, 0)
+        if attempts >= _WAP_PUSH_DELETE_ATTEMPTS:
+            return
+        self._wap_push_attempts[key] = attempts + 1
+        result, problem = _invoke(
+            ["-m", modem_path, f"--messaging-delete-sms={sms_path}"], self.runner, 10)
+        if problem is None and not result.returncode:
+            self._wap_push_attempts.pop(key, None)
 
     def _refresh_topology(self, now: float) -> None:
         topology = []
@@ -484,6 +550,7 @@ class Scanner:
         if topology != self._topology:
             self._details.clear()
             self._local_sms_keys.clear()
+            self._wap_push_attempts.clear()
         self._topology = topology
         # Empty topology is retried quickly so modem hot-plug discovery stays responsive.
         self._topology_expires = now + (self.topology_ttl if topology else min(5.0, self.topology_ttl))
@@ -496,6 +563,7 @@ class Scanner:
             # Object paths and their cached details belong to one ModemManager generation.
             self._details.clear()
             self._local_sms_keys.clear()
+            self._wap_push_attempts.clear()
             self._daemon_epoch = daemon_epoch
         if now >= self._topology_expires:
             self._refresh_topology(now)
@@ -558,9 +626,20 @@ class Scanner:
                 else:
                     sms = _run_json(["-s", sms_path], self.runner).get("sms") or {}
                     content, props = sms.get("content") or {}, sms.get("properties") or {}
-                    text, peer = str(content.get("text") or ""), str(content.get("number") or "")
+                    text, peer = _sms_text(content.get("text")), str(content.get("number") or "")
+                    if str(props.get("state") or "").lower() == "receiving":
+                        # ModemManager is still collecting the parts of a multi-part SMS.
+                        # Import once the assembled text is final; a partial body would be
+                        # stored now and the complete one imported again as a second message.
+                        self._details.pop(key, None)
+                        continue
                     if not text.strip():
                         self._details.pop(key, None)
+                        # A carrier MMS notification has no displayable form here and the
+                        # gateway never retrieves MMS, so nothing will ever consume it. Left
+                        # in place it occupies modem/SIM SMS storage indefinitely.
+                        if self.drop_mms_wap_push and _is_mms_wap_push(content):
+                            self._consume_mms_wap_push(key, modem_path, sms_path)
                         continue
                     pdu_type = str(props.get("pdu-type") or "").lower()
                     direction = "out" if pdu_type == "submit" else "in"
@@ -606,12 +685,18 @@ class Scanner:
                         pass
         # Bound memory when ModemManager deletes SMS objects or a SIM is no longer configured.
         self._details = {key: value for key, value in self._details.items() if key in live_keys}
+        self._wap_push_attempts = {key: value for key, value in self._wap_push_attempts.items()
+                                   if key in live_keys}
         for key in list(self._local_sms_keys):
             if key not in live_local_keys:
                 self._local_sms_keys.pop(key, None)
         return found
 
 
-def discover(instances: list[dict], runner=subprocess.run) -> list[dict]:
-    """One-shot compatibility wrapper used by diagnostics and callers outside the poller."""
-    return Scanner(runner).discover(instances)
+def discover(instances: list[dict], runner=subprocess.run, *,
+             drop_mms_wap_push: bool = False) -> list[dict]:
+    """One-shot compatibility wrapper used by diagnostics and callers outside the poller.
+
+    Deleting an SMS object is the poller's job: a diagnostic read stays free of side effects.
+    """
+    return Scanner(runner, drop_mms_wap_push=drop_mms_wap_push).discover(instances)

--- a/control/app/config.py
+++ b/control/app/config.py
@@ -71,6 +71,12 @@ DEFAULTS = {
         # gives up and CANCELs. 35 covers a normal answer window; most carriers roll to
         # voicemail by ~30s. Shorter = the callee is re-alerted fewer times when unanswered.
         "ring_timeout": 35,
+        # A carrier MMS notification reaches the SMS channel as a WAP Push: no readable text
+        # and a binary WSP payload. The gateway never retrieves MMS, so the object can neither
+        # be shown nor forwarded, and nothing else consumes it -- it holds modem/SIM SMS
+        # storage until that storage is full and no new SMS can be received. Delete it once
+        # recognised. Set false to keep the raw objects for troubleshooting.
+        "drop_mms_wap_push": True,
         # Voicemail defaults. Off unless asked for: recording a caller is the operator's
         # decision. Per-line overrides live in the line's sip.* block, like ring_timeout.
         "vm_enabled": False,

--- a/control/app/main.py
+++ b/control/app/main.py
@@ -1888,7 +1888,13 @@ async def cellular_sms_poller():
     scanner = cellular_sms.Scanner(local_sms_tracker=store)
     while True:
         try:
-            discovered = await asyncio.to_thread(scanner.discover, cfg.list_instances())
+            # One config read serves both the line list and the scanner's policy flag, so the
+            # operator's choice takes effect without restarting the control plane.
+            conf = await asyncio.to_thread(cfg.load)
+            scanner.drop_mms_wap_push = bool(
+                (conf.get("settings") or {}).get("drop_mms_wap_push", True))
+            discovered = await asyncio.to_thread(
+                scanner.discover, list((conf.get("instances") or {}).values()))
             for item in discovered:
                 rec = await asyncio.to_thread(
                     store.add_imported_message, item["fingerprint"], item["instance"],

--- a/tests/test_cellular_sms.py
+++ b/tests/test_cellular_sms.py
@@ -9,6 +9,10 @@ from unittest.mock import patch
 from control.app import cellular_sms, store
 
 TEST_EPOCH = "a" * 64
+MODEM = "/org/freedesktop/ModemManager1/Modem/0"
+SIM = "/org/freedesktop/ModemManager1/SIM/0"
+SMS = "/org/freedesktop/ModemManager1/SMS/7"
+LINE = [{"id": "3", "iccid": "card-a"}]
 
 
 class Result:
@@ -48,6 +52,38 @@ class MemoryTracker:
 
     def cancel_local_modem_sms(self, reservation_id):
         self.calls.append(("cancel", reservation_id))
+
+
+def wap_push_sms() -> dict:
+    """A carrier MMS notification as ModemManager reports it: no text, binary WSP payload."""
+    payload = b"\x23\x06\x24" + b"application/vnd.wap.mms-message" + b"\x00"
+    return {
+        "content": {"number": "+8526335500032116", "text": "--",
+                    "data": " ".join(f"{byte:02X}" for byte in payload)},
+        "properties": {"pdu-type": "deliver", "state": "received",
+                       "timestamp": "2026-09-12T09:00:00+08:00"},
+    }
+
+
+def sms_runner(detail: list, *, calls=None, delete_returncode: int = 0):
+    """One modem holding one SMS object whose detail JSON can be swapped between polls."""
+    def runner(args, **_kwargs):
+        if calls is not None:
+            calls.append(tuple(args))
+        if args == ["mmcli", "-L"]:
+            return Result(MODEM)
+        if args == ["mmcli", "-m", MODEM, "--output-json"]:
+            return Result(json.dumps({"modem": {"generic": {"sim": SIM}}}))
+        if args == ["mmcli", "-i", SIM, "--output-json"]:
+            return Result(json.dumps({"sim": {"properties": {"iccid": "card-a"}}}))
+        if args == ["mmcli", "-m", MODEM, "--messaging-list-sms", "--output-json"]:
+            return Result(json.dumps({"modem.messaging.sms": [SMS]}))
+        if args == ["mmcli", "-s", SMS, "--output-json"]:
+            return Result(json.dumps({"sms": detail[0]}))
+        if args == ["mmcli", "-m", MODEM, f"--messaging-delete-sms={SMS}"]:
+            return Result(returncode=delete_returncode)
+        return Result(returncode=1)
+    return runner
 
 
 class CellularSmsTests(unittest.TestCase):
@@ -182,6 +218,84 @@ class CellularSmsTests(unittest.TestCase):
         listing[0] = {"modem.messaging.sms": ["not-an-object-path"]}
         scanner.discover([{"id": "3", "iccid": "card-a"}])
         self.assertEqual(tracker.prunes, [])
+
+    def test_incomplete_multipart_sms_is_never_imported_as_its_mmcli_placeholder(self):
+        detail = [{
+            "content": {"number": "+44123", "text": "--"},
+            "properties": {"pdu-type": "deliver", "state": "receiving",
+                           "timestamp": "2026-09-12T09:00:00+08:00"},
+        }]
+        runner = sms_runner(detail)
+        now = [10.0]
+        scanner = cellular_sms.Scanner(runner, clock=lambda: now[0])
+
+        self.assertEqual(scanner.discover(LINE), [])
+        # A ModemManager build that reports no state must not import the placeholder either.
+        detail[0]["properties"].pop("state")
+        now[0] += 1
+        self.assertEqual(scanner.discover(LINE), [])
+
+        detail[0] = {
+            "content": {"number": "+44123", "text": "part one and part two"},
+            "properties": {"pdu-type": "deliver", "state": "received",
+                           "timestamp": "2026-09-12T09:00:00+08:00"},
+        }
+        now[0] += 1
+        rows = scanner.discover(LINE)
+        self.assertEqual([row["body"] for row in rows], ["part one and part two"])
+
+    def test_mms_wap_push_notification_is_deleted_instead_of_imported(self):
+        calls = []
+        runner = sms_runner([wap_push_sms()], calls=calls)
+        scanner = cellular_sms.Scanner(runner)
+
+        self.assertEqual(scanner.discover(LINE), [])
+        self.assertIn(("mmcli", "-m", MODEM, f"--messaging-delete-sms={SMS}"), calls)
+
+    def test_mms_wap_push_notification_is_kept_when_dropping_is_disabled(self):
+        calls = []
+        runner = sms_runner([wap_push_sms()], calls=calls)
+        scanner = cellular_sms.Scanner(runner, drop_mms_wap_push=False)
+
+        self.assertEqual(scanner.discover(LINE), [])
+        self.assertNotIn(("mmcli", "-m", MODEM, f"--messaging-delete-sms={SMS}"), calls)
+
+    def test_only_the_wap_push_mime_marker_authorizes_a_delete(self):
+        # An unreadable text alone is not enough: the object may still become importable.
+        detail = [{
+            "content": {"number": "+44123", "text": "--", "data": "01 02 03"},
+            "properties": {"pdu-type": "deliver", "state": "received",
+                           "timestamp": "2026-09-12T09:00:00+08:00"},
+        }]
+        calls = []
+        scanner = cellular_sms.Scanner(sms_runner(detail, calls=calls))
+        self.assertEqual(scanner.discover(LINE), [])
+
+        # Neither is a readable message that happens to carry the marker in its payload.
+        detail[0]["content"] = {"number": "+44123", "text": "hello",
+                                "data": wap_push_sms()["content"]["data"]}
+        rows = scanner.discover(LINE)
+
+        self.assertEqual([row["body"] for row in rows], ["hello"])
+        self.assertNotIn(("mmcli", "-m", MODEM, f"--messaging-delete-sms={SMS}"), calls)
+
+    def test_undeletable_wap_push_stops_retrying_after_its_attempt_budget(self):
+        calls = []
+        runner = sms_runner([wap_push_sms()], calls=calls, delete_returncode=1)
+        scanner = cellular_sms.Scanner(runner)
+        for _ in range(6):
+            self.assertEqual(scanner.discover(LINE), [])
+
+        attempts = calls.count(("mmcli", "-m", MODEM, f"--messaging-delete-sms={SMS}"))
+        self.assertEqual(attempts, cellular_sms._WAP_PUSH_DELETE_ATTEMPTS)
+
+    def test_sms_binary_payload_decoding_tolerates_mmcli_renderings(self):
+        self.assertEqual(cellular_sms._sms_data("23 06 24"), b"\x23\x06\x24")
+        self.assertEqual(cellular_sms._sms_data("230624"), b"\x23\x06\x24")
+        self.assertEqual(cellular_sms._sms_data([35, 6, 36]), b"\x23\x06\x24")
+        self.assertEqual(cellular_sms._sms_data("--"), b"")
+        self.assertEqual(cellular_sms._sms_data(None), b"")
+        self.assertEqual(cellular_sms._sms_data("23 06 2"), b"")
 
     def test_send_matches_case_insensitive_iccid_and_passes_typed_dbus_text(self):
         modem = "/org/freedesktop/ModemManager1/Modem/2"


### PR DESCRIPTION
Closes #84. Closes #85.

Two reports against 1.9.3 from the same ModemManager SMS scanner, both about an SMS object
that has no readable text.

## #84 -- a multi-part SMS imported twice

The first copy read `--`, the second carried the assembled text.

`mmcli` renders an unreadable property as the literal placeholder `--`, and the text of a
multi-part message stays unreadable until every part has arrived. The scanner only skipped an
*empty* body, so it stored the placeholder as a message; when assembly finished the real text
imported as a separate message, because the import fingerprint covers the body.

`config.py` already knew about this placeholder -- `_normalize_iccid` strips it, with a comment
saying so -- but the body path never learned. It does now, and ModemManager's `receiving` state
is a second gate for a build that exposes a partial body instead of the placeholder.

A genuine body of `--` is dropped along with it. That is far rarer than an incomplete
multi-part SMS, which happens on every long message.

## #85 -- carrier MMS notifications accumulating

A WAP Push arrives on the SMS channel with no readable text and a binary WSP payload. The
gateway never retrieves MMS, so it could neither show nor forward the object, and nothing else
consumed it -- it sat in modem/SIM SMS storage forever. On a SIM that receives them regularly
that storage eventually fills and no new SMS can arrive.

The poller now deletes one, gated on `drop_mms_wap_push` (default true). Detection requires
*both* an unreadable text and the standard `application/vnd.wap.mms-message` marker, so it keys
on no carrier's sender number, SMSC or MMSC host.

Deleting is destructive, so it is bounded:
- three failed deletes retire the object, rather than putting an `mmcli` call into every
  five-second poll forever;
- the one-shot `discover()` wrapper never deletes -- a diagnostic read stays side-effect free.

The reporter's own D-Bus workaround confirms such an object can be recognised and removed
safely, but note this PR's `mmcli --messaging-delete-sms` path has **not** run against a real
modem yet; it is covered by tests only.

## Verification

6 new tests, full suite 1116 passing. Reverting just the placeholder fix turns 5 of them red,
so they do pin the reported behaviour rather than merely exercising it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)