### PR TITLE
fix(softphone): place a call without a microphone instead of dying on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,18 @@ All notable changes follow Keep a Changelog and Semantic Versioning.
 
 ### Fixed
 
-- A browser call that fails because the machine has no microphone now says so, before it is
-  even placed. JsSIP's first step is `getUserMedia`, so on a PC with no audio input the call
-  died about ten milliseconds after the click with no INVITE ever sent -- and because JsSIP
-  reports every media failure as one generic cause, the screen showed only "Call ended",
-  which reads as a carrier problem. The dialler now warns while idle when the browser reports
-  no microphone, blocks the dial with the reason (missing, blocked by permission, held by
-  another application, or a non-HTTPS address), and names the cause on the call screen if the
-  device disappears mid-call or an incoming call is answered without one. The Call button also
-  reads the registration indicator it already draws, instead of sending an INVITE into a
-  websocket that is not connected ([#90](https://github.com/MddIdd/mdd-sim-gateway/issues/90)).
+- A browser with no microphone can place and answer calls again, and says what it is doing.
+  JsSIP's first step is `getUserMedia`, so on a PC with no audio input the call died about ten
+  milliseconds after the click with no INVITE ever sent -- and because JsSIP reports every
+  media failure as one generic cause, the screen showed only "Call ended", which reads as a
+  carrier problem. WebRTC needs a local track, but not a microphone: the call now goes out on
+  a silent one, so the carrier is still heard -- which is the whole point of dialling a
+  voicemail box, a service code or an announcement. The dialler says so while idle, the call
+  screen carries a "listen only, the other side cannot hear you" line for the whole call, and
+  Mute is not offered on a track that is already silent. The same fallback applies to
+  answering an incoming call. The Call button also reads the registration indicator it already
+  draws, instead of sending an INVITE into a websocket that is not connected
+  ([#90](https://github.com/MddIdd/mdd-sim-gateway/issues/90)).
 
 ## [1.9.4] - 2026-09-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes follow Keep a Changelog and Semantic Versioning.
 
 ## [Unreleased]
 
+### Fixed
+
+- A browser call that fails because the machine has no microphone now says so, before it is
+  even placed. JsSIP's first step is `getUserMedia`, so on a PC with no audio input the call
+  died about ten milliseconds after the click with no INVITE ever sent -- and because JsSIP
+  reports every media failure as one generic cause, the screen showed only "Call ended",
+  which reads as a carrier problem. The dialler now warns while idle when the browser reports
+  no microphone, blocks the dial with the reason (missing, blocked by permission, held by
+  another application, or a non-HTTPS address), and names the cause on the call screen if the
+  device disappears mid-call or an incoming call is answered without one. The Call button also
+  reads the registration indicator it already draws, instead of sending an INVITE into a
+  websocket that is not connected ([#90](https://github.com/MddIdd/mdd-sim-gateway/issues/90)).
+
 ## [1.9.4] - 2026-09-12
 
 ### Added

--- a/tests/test_ui_softphone_media_preflight.py
+++ b/tests/test_ui_softphone_media_preflight.py
@@ -1,0 +1,130 @@
+"""Issue #90: a dial that dies in the browser must say so, in the browser's terms.
+
+The reported symptom was "click dial, instant disconnect". The console held the answer —
+getUserMedia rejected with NotFoundError, i.e. the machine has no microphone — but JsSIP
+collapses every media failure into one cause ('User Denied Media Access') and the call
+screen collapsed that into "Call ended". The user was left reading a carrier-shaped
+failure for something that never left the page, and chased two websocket ports instead.
+
+These tests hold the three pieces that make the real reason reachable: a probe that runs
+before the call, a named cause after it, and a Call button that reads the status dot it
+already draws.
+"""
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+SOFTPHONE_LIB = (ROOT / "webui/src/softphone.js").read_text(encoding="utf-8")
+SOFTPHONE = (ROOT / "webui/src/views/Softphone.jsx").read_text(encoding="utf-8")
+GLOBAL = (ROOT / "webui/src/GlobalSoftphone.jsx").read_text(encoding="utf-8")
+I18N = (ROOT / "webui/src/i18n.jsx").read_text(encoding="utf-8")
+
+
+def zh_block() -> str:
+    return I18N[I18N.index("const zh"):I18N.index("const en")]
+
+
+def messages() -> dict:
+    """The English strings microphoneMessage() returns, keyed by the reason it maps from."""
+    body = SOFTPHONE_LIB[SOFTPHONE_LIB.index("export function microphoneMessage"):]
+    body = body[:body.index("\n}")]
+    out, pending = {}, []
+    for line in body.splitlines():
+        case = re.match(r"\s*case '([A-Za-z]+)':", line)
+        if case:
+            pending.append(case.group(1))
+            continue
+        ret = re.match(r"\s*return '(.+)'$", line.rstrip())
+        if ret:
+            for reason in pending or ["default"]:
+                out[reason] = ret.group(1)
+            pending = []
+    return out
+
+
+class MicrophoneProbeTests(unittest.TestCase):
+    def test_presence_is_decided_without_opening_the_device(self):
+        """enumerateDevices() needs no permission and starts no capture, so the warning can
+        be shown before the user ever clicks. Opening the microphone to test it would
+        prompt, and would hand JsSIP a device it then has to re-acquire."""
+        probe = SOFTPHONE_LIB[SOFTPHONE_LIB.index("export async function audioInputPresence"):]
+        probe = probe[:probe.index("\n}")]
+        self.assertIn("enumerateDevices()", probe)
+        self.assertNotIn("getUserMedia({", probe)
+        self.assertIn("device.kind === 'audioinput'", probe)
+
+    def test_a_withheld_device_list_is_not_read_as_a_missing_microphone(self):
+        """Browsers that hide device info until permission is granted return an empty list.
+        Warning on that would accuse every such browser of having no microphone."""
+        probe = SOFTPHONE_LIB[SOFTPHONE_LIB.index("export async function audioInputPresence"):]
+        probe = probe[:probe.index("\n}")]
+        self.assertIn("if (!devices.length) return 'unknown'", probe)
+        self.assertIn("catch { return 'unknown' }", probe)
+
+    def test_the_banner_only_appears_once_the_probe_has_answered(self):
+        self.assertIn("useState('present')", SOFTPHONE)
+        self.assertIn("micPresence === 'none' || micPresence === 'insecure'", SOFTPHONE)
+        self.assertIn("'devicechange', probe", SOFTPHONE)
+
+    def test_every_failure_the_browser_can_report_has_its_own_advice(self):
+        found = messages()
+        for reason in ("NotFoundError", "NotAllowedError", "NotReadableError",
+                       "insecure", "default"):
+            self.assertIn(reason, found, f"no microphone message for {reason}")
+        self.assertEqual(len(set(found.values())), 5, "advice must differ per reason")
+
+    def test_every_microphone_message_is_translated(self):
+        block = zh_block()
+        missing = [text for text in set(messages().values()) if f"'{text}'" not in block]
+        self.assertEqual(missing, [], f"untranslated microphone messages: {missing}")
+
+
+class PreDialGuardTests(unittest.TestCase):
+    def test_the_microphone_is_checked_before_the_invite(self):
+        dial = SOFTPHONE[SOFTPHONE.index("const placeCall ="):]
+        dial = dial[:dial.index("\n  const answer =")]
+        self.assertLess(dial.index("await audioInputPresence()"), dial.index("phone.current.call(target)"))
+        self.assertIn("toast(t(microphoneMessage(presence)))", dial)
+
+    def test_the_audio_sink_is_still_primed_inside_the_click(self):
+        """unlockAudio() must run before the first await or the transient user activation is
+        gone and remote audio silently fails to play later."""
+        dial = SOFTPHONE[SOFTPHONE.index("const placeCall ="):]
+        dial = dial[:dial.index("\n  const answer =")]
+        self.assertLess(dial.index("phone.current.unlockAudio()"), dial.index("await audioInputPresence()"))
+
+    def test_the_call_button_reads_the_registration_state_it_displays(self):
+        dial = SOFTPHONE[SOFTPHONE.index("const placeCall ="):]
+        dial = dial[:dial.index("\n  const answer =")]
+        guard = re.search(r"\[([^\]]+)\]\.includes\(reg\)", dial)
+        self.assertIsNotNone(guard, "the Call button does not consult the registration state")
+        blocked = set(re.findall(r"'([a-z]+)'", guard.group(1)))
+        self.assertEqual(blocked, {"disconnected", "failed", "unregistered"})
+        # A websocket that is still opening may well carry the call; do not block it.
+        self.assertNotIn("connecting", blocked)
+
+
+class NamedCauseTests(unittest.TestCase):
+    def test_a_media_failure_is_not_reported_as_a_finished_call(self):
+        self.assertIn("export const MEDIA_FAIL_CAUSE = 'User Denied Media Access'", SOFTPHONE_LIB)
+        self.assertIn("c === MEDIA_FAIL_CAUSE ? 'Microphone unavailable'", SOFTPHONE)
+        self.assertIn("'Microphone unavailable':", zh_block())
+
+    def test_the_browser_s_own_error_name_is_carried_up(self):
+        """JsSIP fires the session's 'failed' BEFORE 'getusermediafailed', so the generic
+        cause arrives first and only this event carries the DOMException name."""
+        self.assertIn("session.on('getusermediafailed'", SOFTPHONE_LIB)
+        self.assertIn("this.emit('mediafail', (err && err.name) || 'MediaError')", SOFTPHONE_LIB)
+
+    def test_both_call_surfaces_explain_it(self):
+        # Answering an incoming call starts with getUserMedia too, and the global overlay
+        # has no pre-dial check to fall back on.
+        self.assertIn("type === 'mediafail'", SOFTPHONE)
+        self.assertIn("type === 'mediafail'", GLOBAL)
+        self.assertIn("microphoneMessage(data)", GLOBAL)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ui_softphone_media_preflight.py
+++ b/tests/test_ui_softphone_media_preflight.py
@@ -1,14 +1,16 @@
-"""Issue #90: a dial that dies in the browser must say so, in the browser's terms.
+"""Issue #90: a browser with no microphone must still be able to call, and must say so.
 
 The reported symptom was "click dial, instant disconnect". The console held the answer —
 getUserMedia rejected with NotFoundError, i.e. the machine has no microphone — but JsSIP
 collapses every media failure into one cause ('User Denied Media Access') and the call
-screen collapsed that into "Call ended". The user was left reading a carrier-shaped
-failure for something that never left the page, and chased two websocket ports instead.
+screen collapsed that into "Call ended". The user was left reading a carrier-shaped failure
+for something that never left the page, and chased two websocket ports instead.
 
-These tests hold the three pieces that make the real reason reachable: a probe that runs
-before the call, a named cause after it, and a Call button that reads the status dot it
-already draws.
+WebRTC cannot offer a call without a local audio track, but it does not care what is on it.
+A call placed on silence still carries the carrier's audio, which is the whole point of
+dialling a voicemail box, a service code or an announcement — so the microphone decides how
+the call sounds, not whether it happens. These tests hold that: the call goes out either
+way, every surface says which of the two it got, and the substituted track is cleaned up.
 """
 import re
 import unittest
@@ -21,15 +23,21 @@ SOFTPHONE = (ROOT / "webui/src/views/Softphone.jsx").read_text(encoding="utf-8")
 GLOBAL = (ROOT / "webui/src/GlobalSoftphone.jsx").read_text(encoding="utf-8")
 I18N = (ROOT / "webui/src/i18n.jsx").read_text(encoding="utf-8")
 
+LISTEN_ONLY = "Listen only · the other side cannot hear you"
+
 
 def zh_block() -> str:
     return I18N[I18N.index("const zh"):I18N.index("const en")]
 
 
+def block(source: str, start: str, end: str = "\n  }") -> str:
+    body = source[source.index(start):]
+    return body[:body.index(end)]
+
+
 def messages() -> dict:
     """The English strings microphoneMessage() returns, keyed by the reason it maps from."""
-    body = SOFTPHONE_LIB[SOFTPHONE_LIB.index("export function microphoneMessage"):]
-    body = body[:body.index("\n}")]
+    body = block(SOFTPHONE_LIB, "export function microphoneMessage", "\n}")
     out, pending = {}, []
     for line in body.splitlines():
         case = re.match(r"\s*case '([A-Za-z]+)':", line)
@@ -44,86 +52,126 @@ def messages() -> dict:
     return out
 
 
-class MicrophoneProbeTests(unittest.TestCase):
-    def test_presence_is_decided_without_opening_the_device(self):
-        """enumerateDevices() needs no permission and starts no capture, so the warning can
-        be shown before the user ever clicks. Opening the microphone to test it would
-        prompt, and would hand JsSIP a device it then has to re-acquire."""
-        probe = SOFTPHONE_LIB[SOFTPHONE_LIB.index("export async function audioInputPresence"):]
-        probe = probe[:probe.index("\n}")]
-        self.assertIn("enumerateDevices()", probe)
-        self.assertNotIn("getUserMedia({", probe)
-        self.assertIn("device.kind === 'audioinput'", probe)
+class CallsSurviveAMissingMicrophoneTests(unittest.TestCase):
+    def test_the_local_audio_is_acquired_by_us_not_by_jssip(self):
+        """JsSIP's own getUserMedia call ends the session when it rejects — that is the bug.
+        Passing it a stream (mediaStream) skips that path entirely."""
+        acquire = block(SOFTPHONE_LIB, "  async _acquireLocal()")
+        self.assertIn("getUserMedia({ audio: true })", acquire)
+        self.assertIn("silentAudioStream()", acquire)
+        dial = block(SOFTPHONE_LIB, "  async call(number)")
+        self.assertIn("mediaStream: local.stream || undefined", dial)
 
-    def test_a_withheld_device_list_is_not_read_as_a_missing_microphone(self):
-        """Browsers that hide device info until permission is granted return an empty list.
-        Warning on that would accuse every such browser of having no microphone."""
-        probe = SOFTPHONE_LIB[SOFTPHONE_LIB.index("export async function audioInputPresence"):]
-        probe = probe[:probe.index("\n}")]
-        self.assertIn("if (!devices.length) return 'unknown'", probe)
-        self.assertIn("catch { return 'unknown' }", probe)
+    def test_answering_gets_the_same_fallback_as_dialling(self):
+        answer = block(SOFTPHONE_LIB, "  async answer()")
+        self.assertIn("await this._acquireLocal()", answer)
+        self.assertIn("mediaStream: local.stream || undefined", answer)
+        self.assertIn("this.emit('mediafallback'", answer)
 
-    def test_the_banner_only_appears_once_the_probe_has_answered(self):
-        self.assertIn("useState('present')", SOFTPHONE)
-        self.assertIn("micPresence === 'none' || micPresence === 'insecure'", SOFTPHONE)
-        self.assertIn("'devicechange', probe", SOFTPHONE)
+    def test_the_silent_track_really_produces_frames(self):
+        """A destination node with nothing connected to it can deliver no audio at all; an
+        oscillator at zero gain keeps the graph running while staying silent."""
+        silent = block(SOFTPHONE_LIB, "function silentAudioStream()", "\n}")
+        self.assertIn("createMediaStreamDestination()", silent)
+        self.assertIn("gain.gain.value = 0", silent)
+        self.assertIn("osc.start()", silent)
 
-    def test_every_failure_the_browser_can_report_has_its_own_advice(self):
+    def test_a_stream_we_passed_in_is_released_by_us(self):
+        """JsSIP only stops tracks it generated itself, so a microphone handed to it stays
+        open — and the browser's recording indicator stays lit — unless we stop it."""
+        release = block(SOFTPHONE_LIB, "  _releaseLocal()")
+        self.assertIn("track.stop()", release)
+        self.assertIn("local.ctx?.close()", release)
+        self.assertIn("this._releaseLocal()", block(SOFTPHONE_LIB, "  hangup()"))
+        # stop() releases by going through hangup(); a second call would be dead code.
+        self.assertIn("this.hangup()", block(SOFTPHONE_LIB, "  stop()"))
+        self.assertIn("this._releaseLocal(); this.emit('ended'", SOFTPHONE_LIB)
+        self.assertIn("this._releaseLocal(); this.emit('failed'", SOFTPHONE_LIB)
+
+    def test_a_teardown_during_the_prompt_does_not_raise_a_call(self):
+        """getUserMedia can sit on a permission prompt for as long as the user likes; the
+        line may be switched away in the meantime."""
+        dial = block(SOFTPHONE_LIB, "  async call(number)")
+        self.assertIn("if (this._dead || !this.ua) { this._releaseLocal(); return }", dial)
+
+    def test_nothing_in_the_dial_path_refuses_the_call(self):
+        dial = block(SOFTPHONE, "  const placeCall =", "\n  const answer =")
+        self.assertNotIn("audioInputPresence()", dial)
+        self.assertIn("phone.current.call(target)", dial)
+
+    def test_the_audio_sink_is_still_primed_inside_the_click(self):
+        """unlockAudio() must run before call() awaits anything, or the transient user
+        activation is gone and remote audio silently fails to play."""
+        dial = block(SOFTPHONE, "  const placeCall =", "\n  const answer =")
+        self.assertLess(dial.index("phone.current.unlockAudio()"), dial.index("phone.current.call(target)"))
+
+
+class SayingSoTests(unittest.TestCase):
+    def test_every_failure_the_browser_can_report_has_its_own_wording(self):
         found = messages()
         for reason in ("NotFoundError", "NotAllowedError", "NotReadableError",
                        "insecure", "default"):
             self.assertIn(reason, found, f"no microphone message for {reason}")
-        self.assertEqual(len(set(found.values())), 5, "advice must differ per reason")
+        self.assertEqual(len(set(found.values())), 5, "wording must differ per reason")
+
+    def test_no_message_claims_the_call_cannot_be_placed(self):
+        for text in messages().values():
+            self.assertIn("can still be placed", text, text)
+            self.assertIn("will not hear you", text, text)
 
     def test_every_microphone_message_is_translated(self):
-        block = zh_block()
-        missing = [text for text in set(messages().values()) if f"'{text}'" not in block]
+        block_zh = zh_block()
+        missing = [text for text in set(messages().values()) if f"'{text}'" not in block_zh]
         self.assertEqual(missing, [], f"untranslated microphone messages: {missing}")
+        self.assertIn(f"'{LISTEN_ONLY}'", block_zh)
+
+    def test_the_notice_is_shown_idle_and_for_the_whole_call(self):
+        # Idle: the probe needs no permission, so the page can warn before anything is dialled.
+        self.assertIn("useState('present')", SOFTPHONE)
+        self.assertIn("micPresence === 'none' || micPresence === 'insecure'", SOFTPHONE)
+        self.assertIn("'devicechange', probe", SOFTPHONE)
+        # In call: a toast scrolls away, the call screen does not.
+        self.assertIn(f"t('{LISTEN_ONLY}')", SOFTPHONE)
+        self.assertEqual(SOFTPHONE.count("<ListenOnlyNote t={t} />"), 2,
+                         "both the ringing and the connected screen must say it")
+
+    def test_the_flag_belongs_to_one_call(self):
+        """A call placed before the headset was unplugged is still a normal call; the notice
+        must come from what THIS call actually got, not from the current device list."""
+        self.assertIn("const [listenOnly, setListenOnly] = useState(null)", SOFTPHONE)
+        self.assertIn("type === 'mediafallback') { setListenOnly(data)", SOFTPHONE)
+        self.assertIn("setListenOnly(null); setCall({ dir: 'out'", SOFTPHONE)
+        self.assertIn("if (!call) setListenOnly(null)", SOFTPHONE)
+
+    def test_mute_is_not_offered_on_a_silent_track(self):
+        """A toggle that cannot change anything reads as a broken button."""
+        self.assertIn("disabled={Boolean(listenOnly)}", SOFTPHONE)
+        self.assertIn("function RoundBtn({ icon, label, color, bg, onClick, active, disabled = false })", SOFTPHONE)
+
+    def test_the_global_overlay_says_it_too(self):
+        # Answering from the overlay has no dialler screen to fall back on.
+        self.assertIn("type === 'mediafallback'", GLOBAL)
+        self.assertIn("{ ...current, listenOnly: true }", GLOBAL)
+        self.assertIn(f"t('{LISTEN_ONLY}')", GLOBAL)
+
+    def test_a_hard_media_failure_is_still_named(self):
+        """If even a silent track cannot be built, JsSIP asks for the microphone itself and
+        the call does die — with the one generic cause the UI used to render as 'Call ended'."""
+        self.assertIn("export const MEDIA_FAIL_CAUSE = 'User Denied Media Access'", SOFTPHONE_LIB)
+        self.assertIn("session.on('getusermediafailed'", SOFTPHONE_LIB)
+        self.assertIn("c === MEDIA_FAIL_CAUSE ? 'Microphone unavailable'", SOFTPHONE)
+        self.assertIn("'Microphone unavailable':", zh_block())
 
 
-class PreDialGuardTests(unittest.TestCase):
-    def test_the_microphone_is_checked_before_the_invite(self):
-        dial = SOFTPHONE[SOFTPHONE.index("const placeCall ="):]
-        dial = dial[:dial.index("\n  const answer =")]
-        self.assertLess(dial.index("await audioInputPresence()"), dial.index("phone.current.call(target)"))
-        self.assertIn("toast(t(microphoneMessage(presence)))", dial)
-
-    def test_the_audio_sink_is_still_primed_inside_the_click(self):
-        """unlockAudio() must run before the first await or the transient user activation is
-        gone and remote audio silently fails to play later."""
-        dial = SOFTPHONE[SOFTPHONE.index("const placeCall ="):]
-        dial = dial[:dial.index("\n  const answer =")]
-        self.assertLess(dial.index("phone.current.unlockAudio()"), dial.index("await audioInputPresence()"))
-
+class RegistrationGuardTests(unittest.TestCase):
     def test_the_call_button_reads_the_registration_state_it_displays(self):
-        dial = SOFTPHONE[SOFTPHONE.index("const placeCall ="):]
-        dial = dial[:dial.index("\n  const answer =")]
+        dial = block(SOFTPHONE, "  const placeCall =", "\n  const answer =")
         guard = re.search(r"\[([^\]]+)\]\.includes\(reg\)", dial)
         self.assertIsNotNone(guard, "the Call button does not consult the registration state")
         blocked = set(re.findall(r"'([a-z]+)'", guard.group(1)))
         self.assertEqual(blocked, {"disconnected", "failed", "unregistered"})
         # A websocket that is still opening may well carry the call; do not block it.
         self.assertNotIn("connecting", blocked)
-
-
-class NamedCauseTests(unittest.TestCase):
-    def test_a_media_failure_is_not_reported_as_a_finished_call(self):
-        self.assertIn("export const MEDIA_FAIL_CAUSE = 'User Denied Media Access'", SOFTPHONE_LIB)
-        self.assertIn("c === MEDIA_FAIL_CAUSE ? 'Microphone unavailable'", SOFTPHONE)
-        self.assertIn("'Microphone unavailable':", zh_block())
-
-    def test_the_browser_s_own_error_name_is_carried_up(self):
-        """JsSIP fires the session's 'failed' BEFORE 'getusermediafailed', so the generic
-        cause arrives first and only this event carries the DOMException name."""
-        self.assertIn("session.on('getusermediafailed'", SOFTPHONE_LIB)
-        self.assertIn("this.emit('mediafail', (err && err.name) || 'MediaError')", SOFTPHONE_LIB)
-
-    def test_both_call_surfaces_explain_it(self):
-        # Answering an incoming call starts with getUserMedia too, and the global overlay
-        # has no pre-dial check to fall back on.
-        self.assertIn("type === 'mediafail'", SOFTPHONE)
-        self.assertIn("type === 'mediafail'", GLOBAL)
-        self.assertIn("microphoneMessage(data)", GLOBAL)
 
 
 if __name__ == "__main__":

--- a/webui/src/GlobalSoftphone.jsx
+++ b/webui/src/GlobalSoftphone.jsx
@@ -67,9 +67,13 @@ export default function GlobalSoftphone({ instances, excludedId, showToast }) {
             setCall((current) => current ? { ...current, state: 'ended', endCause: data?.cause } : current)
             setMuted(false)
             clearTimer.current = setTimeout(() => setCall(null), 1800)
+          } else if (type === 'mediafallback') {
+            // Answered without a microphone: the caller is audible, the user is not. Say so
+            // on the overlay for the whole call, not just in a toast that scrolls away.
+            setCall((current) => current?.id === id ? { ...current, listenOnly: true } : current)
+            showToast?.(t(microphoneMessage(data)))
           } else if (type === 'mediafail') {
-            // Answering also starts with getUserMedia, so an incoming call dies the same way
-            // an outgoing one does — and the overlay would only say "Call ended".
+            // Last resort: not even a silent track could be built, so the call really died.
             showToast?.(t(microphoneMessage(data)))
           } else if (type === 'audioblocked') {
             showToast?.(t('Browser blocked call audio. Click the page once and try again.'))
@@ -121,6 +125,9 @@ export default function GlobalSoftphone({ instances, excludedId, showToast }) {
       <div className="mono" style={{ fontSize: 26, fontWeight: 800 }}>{call.number}</div>
       <div style={{ fontSize: 13, color: 'var(--text-mute)', marginTop: 7 }}>{call.line}</div>
       {call.state === 'active' && <div className="mono" style={{ color: GREEN, marginTop: 12 }}>{clock}</div>}
+      {call.listenOnly && call.state !== 'ended' && <div style={{ fontSize: 12, color: '#f59e0b', marginTop: 8 }}>
+        {t('Listen only · the other side cannot hear you')}
+      </div>}
 
       {call.state === 'incoming' && <div style={{ display: 'flex', justifyContent: 'center', gap: 56, marginTop: 34 }}>
         <ActionButton label={t('Decline')} icon="✕" color={RED} onClick={decline} />

--- a/webui/src/GlobalSoftphone.jsx
+++ b/webui/src/GlobalSoftphone.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { api } from './api.js'
-import { Softphone as Phone } from './softphone.js'
+import { Softphone as Phone, microphoneMessage } from './softphone.js'
 import { useI18n } from './i18n.jsx'
 
 const GREEN = '#22c55e'
@@ -67,6 +67,10 @@ export default function GlobalSoftphone({ instances, excludedId, showToast }) {
             setCall((current) => current ? { ...current, state: 'ended', endCause: data?.cause } : current)
             setMuted(false)
             clearTimer.current = setTimeout(() => setCall(null), 1800)
+          } else if (type === 'mediafail') {
+            // Answering also starts with getUserMedia, so an incoming call dies the same way
+            // an outgoing one does — and the overlay would only say "Call ended".
+            showToast?.(t(microphoneMessage(data)))
           } else if (type === 'audioblocked') {
             showToast?.(t('Browser blocked call audio. Click the page once and try again.'))
           }

--- a/webui/src/i18n.jsx
+++ b/webui/src/i18n.jsx
@@ -211,16 +211,18 @@ const zh = {
   'Carrier replied': '运营商已回复',
   'This browser has WebRTC disabled, so no call can be placed. A privacy or ad-blocking extension is the usual cause — allow WebRTC for this site, or open it in a private window.':
     '此浏览器已禁用 WebRTC，无法拨打电话。通常是隐私或广告拦截扩展所致——请为本站点放行 WebRTC，或改用无痕窗口打开。',
-  'No microphone was found, so this browser cannot place a call. Connect a microphone or headset — or use a device that has one — and try again.':
-    '未检测到麦克风，此浏览器无法拨打电话。请接入麦克风或耳机（或换用带麦克风的设备）后重试。',
-  'This site is not allowed to use the microphone, so the call cannot be placed. Allow microphone access for this site in the browser, then try again.':
-    '浏览器未允许本站点使用麦克风，无法拨打电话。请在浏览器中为本站点放行麦克风权限后重试。',
-  'The microphone is being held by another application, so the call cannot be placed. Close whatever is using it, then try again.':
-    '麦克风正被其他程序占用，无法拨打电话。请关闭占用麦克风的程序后重试。',
-  'Browsers only allow microphone access over HTTPS, so no call can be placed on this address. Open the web interface over HTTPS and try again.':
-    '浏览器仅在 HTTPS 下允许使用麦克风，当前地址无法拨打电话。请改用 HTTPS 访问 Web 界面后重试。',
-  'The browser could not open the microphone, so the call cannot be placed.':
-    '浏览器无法打开麦克风，无法拨打电话。',
+  'No microphone was found. Calls can still be placed and you will hear the other side, but they will not hear you.':
+    '未检测到麦克风。仍可拨打电话，你能听到对方，但对方听不到你。接入麦克风或耳机后重新拨号即可正常通话。',
+  'Microphone access is blocked for this site. Calls can still be placed and you will hear the other side, but they will not hear you until you allow it in the browser.':
+    '浏览器未允许本站点使用麦克风。仍可拨打电话，你能听到对方，但在浏览器中放行麦克风权限之前，对方听不到你。',
+  'The microphone is being held by another application. Calls can still be placed and you will hear the other side, but they will not hear you until it is released.':
+    '麦克风正被其他程序占用。仍可拨打电话，你能听到对方，但在占用解除之前，对方听不到你。',
+  'Browsers only allow microphone access over HTTPS. Calls can still be placed on this address and you will hear the other side, but they will not hear you.':
+    '浏览器仅在 HTTPS 下允许使用麦克风。当前地址仍可拨打电话，你能听到对方，但对方听不到你。',
+  'The browser could not open the microphone. Calls can still be placed and you will hear the other side, but they will not hear you.':
+    '浏览器无法打开麦克风。仍可拨打电话，你能听到对方，但对方听不到你。',
+  'Listen only · the other side cannot hear you': '仅收听 · 对方听不到你的声音',
+  'No mic': '无麦克风',
   'Microphone unavailable': '麦克风不可用',
   'This browser is not connected to the line’s engine, so the call cannot be placed. Check that the engine for this SIM is running.':
     '浏览器尚未连接到该线路的引擎，无法拨打电话。请确认该卡的引擎正在运行。',

--- a/webui/src/i18n.jsx
+++ b/webui/src/i18n.jsx
@@ -211,6 +211,21 @@ const zh = {
   'Carrier replied': '运营商已回复',
   'This browser has WebRTC disabled, so no call can be placed. A privacy or ad-blocking extension is the usual cause — allow WebRTC for this site, or open it in a private window.':
     '此浏览器已禁用 WebRTC，无法拨打电话。通常是隐私或广告拦截扩展所致——请为本站点放行 WebRTC，或改用无痕窗口打开。',
+  'No microphone was found, so this browser cannot place a call. Connect a microphone or headset — or use a device that has one — and try again.':
+    '未检测到麦克风，此浏览器无法拨打电话。请接入麦克风或耳机（或换用带麦克风的设备）后重试。',
+  'This site is not allowed to use the microphone, so the call cannot be placed. Allow microphone access for this site in the browser, then try again.':
+    '浏览器未允许本站点使用麦克风，无法拨打电话。请在浏览器中为本站点放行麦克风权限后重试。',
+  'The microphone is being held by another application, so the call cannot be placed. Close whatever is using it, then try again.':
+    '麦克风正被其他程序占用，无法拨打电话。请关闭占用麦克风的程序后重试。',
+  'Browsers only allow microphone access over HTTPS, so no call can be placed on this address. Open the web interface over HTTPS and try again.':
+    '浏览器仅在 HTTPS 下允许使用麦克风，当前地址无法拨打电话。请改用 HTTPS 访问 Web 界面后重试。',
+  'The browser could not open the microphone, so the call cannot be placed.':
+    '浏览器无法打开麦克风，无法拨打电话。',
+  'Microphone unavailable': '麦克风不可用',
+  'This browser is not connected to the line’s engine, so the call cannot be placed. Check that the engine for this SIM is running.':
+    '浏览器尚未连接到该线路的引擎，无法拨打电话。请确认该卡的引擎正在运行。',
+  'This line is not registered right now, so the call cannot be placed. Wait for the Registered indicator, or check the line’s VoWiFi status.':
+    '该线路当前未注册成功，无法拨打电话。请等待状态变为“已注册”，或检查该线路的 VoWiFi 状态。',
   'The gateway did not send this code. Its engine image may be older than service-code support — reload the installation to update it.':
     '网关未能送出该代码。引擎镜像可能早于服务码支持——请重新加载安装以更新引擎。',
   'Carrier accepted the code. This kind of code returns no text.':

--- a/webui/src/softphone.js
+++ b/webui/src/softphone.js
@@ -29,24 +29,47 @@ export async function audioInputPresence() {
 }
 
 // What to tell the user, keyed by the DOMException name the browser reported (or a presence
-// verdict). The returned strings are the i18n keys; the caller translates them.
+// verdict). None of these stop a call: a call with no microphone still carries the carrier's
+// audio and is worth placing (a voicemail box, a service code, an announcement). They say
+// what the call WILL be, so nobody discovers it by being unheard. The returned strings are
+// the i18n keys; the caller translates them.
 export function microphoneMessage(reason) {
   switch (reason) {
     case 'none':
     case 'NotFoundError':
     case 'DevicesNotFoundError':      // legacy Chrome name for the same condition
-      return 'No microphone was found, so this browser cannot place a call. Connect a microphone or headset — or use a device that has one — and try again.'
+      return 'No microphone was found. Calls can still be placed and you will hear the other side, but they will not hear you.'
     case 'NotAllowedError':
     case 'PermissionDeniedError':
-      return 'This site is not allowed to use the microphone, so the call cannot be placed. Allow microphone access for this site in the browser, then try again.'
+      return 'Microphone access is blocked for this site. Calls can still be placed and you will hear the other side, but they will not hear you until you allow it in the browser.'
     case 'NotReadableError':
     case 'TrackStartError':
-      return 'The microphone is being held by another application, so the call cannot be placed. Close whatever is using it, then try again.'
+      return 'The microphone is being held by another application. Calls can still be placed and you will hear the other side, but they will not hear you until it is released.'
     case 'insecure':
-      return 'Browsers only allow microphone access over HTTPS, so no call can be placed on this address. Open the web interface over HTTPS and try again.'
+      return 'Browsers only allow microphone access over HTTPS. Calls can still be placed on this address and you will hear the other side, but they will not hear you.'
     default:
-      return 'The browser could not open the microphone, so the call cannot be placed.'
+      return 'The browser could not open the microphone. Calls can still be placed and you will hear the other side, but they will not hear you.'
   }
+}
+
+// A local audio track is not optional: WebRTC has no offer to make without one, which is why
+// a missing microphone used to end the call before an INVITE was ever sent. Silence is a
+// perfectly good track. An oscillator at zero gain keeps the graph running so the destination
+// really does produce (empty) frames rather than nothing at all.
+function silentAudioStream() {
+  const Ctx = window.AudioContext || window.webkitAudioContext
+  if (!Ctx) return null
+  try {
+    const ctx = new Ctx()
+    const dest = ctx.createMediaStreamDestination()
+    const osc = ctx.createOscillator()
+    const gain = ctx.createGain()
+    gain.gain.value = 0
+    osc.connect(gain).connect(dest)
+    osc.start()
+    ctx.resume?.().catch?.(() => {})
+    return { stream: dest.stream, ctx, osc }
+  } catch { return null }
 }
 
 export class Softphone {
@@ -64,6 +87,7 @@ export class Softphone {
     this._rec = null
     this._recCtx = null
     this._recChunks = []
+    this._local = null                // local audio handed to JsSIP; ours to release
   }
 
   emit(type, data) { try { this.onEvent(type, data) } catch {} }
@@ -189,8 +213,8 @@ export class Softphone {
     // 'ended' (BYE received/sent) and 'failed' (setup error / non-2xx) are the terminal
     // events. Always null the session and tell the view so the UI resets to idle even if
     // only one of them fires.
-    session.on('ended', (d) => { if (this.session === session) this.session = null; this.emit('ended', { cause: d && d.cause }) })
-    session.on('failed', (d) => { if (this.session === session) this.session = null; this.emit('failed', { cause: d && d.cause }) })
+    session.on('ended', (d) => { if (this.session === session) this.session = null; this._releaseLocal(); this.emit('ended', { cause: d && d.cause }) })
+    session.on('failed', (d) => { if (this.session === session) this.session = null; this._releaseLocal(); this.emit('failed', { cause: d && d.cause }) })
     session.on('peerconnection', (ev) => {
       const pc = ev.peerconnection
       // ontrack fires as the remote audio track arrives. te.streams[0] is the usual source,
@@ -227,14 +251,51 @@ export class Softphone {
     } catch {}
   }
 
-  call(number) {
+  // Open the local audio for a call. JsSIP would do this itself, but only by calling
+  // getUserMedia and killing the whole session if it rejects — which is how a PC with no
+  // microphone lost the call ~10ms after the click. Take it over: hand JsSIP a real stream
+  // when there is one, and silence when there is not, so the call is placed either way and
+  // the UI can say which of the two it got.
+  async _acquireLocal() {
+    this._releaseLocal()              // never leave a previous call's track open
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+      this._local = { stream, silent: false }
+    } catch (err) {
+      // navigator.mediaDevices is absent on an insecure origin, so the failure there is a
+      // TypeError from the call itself rather than a DOMException that names a device fault.
+      const reason = !navigator.mediaDevices ? 'insecure' : (err && err.name) || 'MediaError'
+      const silent = silentAudioStream()
+      this._local = { ...(silent || { stream: null }), silent: true, reason }
+    }
+    return this._local
+  }
+
+  // JsSIP only stops tracks it generated itself, so a stream we passed in stays live (and the
+  // browser keeps showing the recording indicator) unless we release it here.
+  _releaseLocal() {
+    const local = this._local
+    this._local = null
+    if (!local) return
+    try { local.stream?.getTracks().forEach((track) => track.stop()) } catch {}
+    try { local.osc?.stop() } catch {}
+    try { local.ctx?.close() } catch {}
+  }
+
+  async call(number) {
     if (!this.ua) return
     const domain = this.ua.configuration.uri.host
+    this.emit('calling', { to: number })
+    const local = await this._acquireLocal()
+    // stop() can land while getUserMedia is still deciding (the user switched lines, or the
+    // page navigated away). Do not raise a call on a torn-down UA.
+    if (this._dead || !this.ua) { this._releaseLocal(); return }
+    if (local.silent) this.emit('mediafallback', local.reason)
     const opts = {
       mediaConstraints: { audio: true, video: false },
+      mediaStream: local.stream || undefined,
       pcConfig: { rtcpMuxPolicy: 'require', iceServers: [] },
     }
-    this.emit('calling', { to: number })
     // '#' is not a legal SIP URI user character (RFC 3261 25.1), and JsSIP rejects the whole
     // URI rather than escaping it, so service codes like #225# would never leave the browser.
     // Asterisk percent-decodes the user part before dialplan matching, so EXTEN is unchanged.
@@ -246,13 +307,29 @@ export class Softphone {
       // ua.call() can throw synchronously (bad target, no media, etc.) before any session
       // event fires — surface it as a terminal 'failed' so the UI doesn't hang on "calling".
       this.session = null
+      this._releaseLocal()
       this.emit('failed', { cause: (err && err.message) || 'Call failed' })
     }
   }
 
-  answer() {
-    if (this.session) {
-      this.session.answer({ mediaConstraints: { audio: true, video: false }, pcConfig: { iceServers: [] } })
+  // Answering runs through the same media path as dialling, so an incoming call is answerable
+  // without a microphone too — the caller is heard, and the UI says they cannot hear back.
+  async answer() {
+    const session = this.session
+    if (!session) return
+    const local = await this._acquireLocal()
+    if (this._dead || this.session !== session) { this._releaseLocal(); return }
+    if (local.silent) this.emit('mediafallback', local.reason)
+    try {
+      session.answer({ mediaConstraints: { audio: true, video: false },
+                       mediaStream: local.stream || undefined, pcConfig: { iceServers: [] } })
+    } catch (err) {
+      // answer() throws synchronously on a session that is no longer answerable. Awaiting the
+      // media above means that throw would otherwise surface as an unhandled rejection and
+      // leave the overlay ringing at a call that is already gone.
+      this.session = null
+      this._releaseLocal()
+      this.emit('failed', { cause: (err && err.message) || 'Answer failed' })
     }
   }
 
@@ -262,6 +339,7 @@ export class Softphone {
       this.session = null
       try { s.terminate() } catch {}
     }
+    this._releaseLocal()
   }
 
   // Reject an un-answered INCOMING call. JsSIP's bare terminate() on a ringing incoming
@@ -336,7 +414,7 @@ export class Softphone {
     // Mark dead FIRST so any late JsSIP event from ua.stop() (async 'disconnected'/'unregistered')
     // is swallowed by emit() and cannot clobber a newly-started line's state.
     this._dead = true
-    this.hangup()
+    this.hangup()                     // releases the local track on its way through
     if (this._rec) { try { this._rec.stop() } catch {}; this._rec = null }
     if (this.ua) { try { this.ua.stop() } catch {} this.ua = null }
     if (this.remoteAudio) {

--- a/webui/src/softphone.js
+++ b/webui/src/softphone.js
@@ -4,6 +4,51 @@ import JsSIP from 'jssip'
 // Surface JsSIP internals in the console to aid troubleshooting (registration, ICE, etc.)
 try { JsSIP.debug.enable('JsSIP:*') } catch {}
 
+// A call can die about ten milliseconds after the click with no INVITE ever sent, because
+// JsSIP's very first step is getUserMedia: no microphone, no call. JsSIP reports every one of
+// those failures as the single cause 'User Denied Media Access' (RTCSession's getUserMedia
+// catch), which says nothing about a machine that simply has no audio input — the case
+// reported from a desktop browser, where the dial screen vanished instantly and the console
+// showed only NotFoundError. Name the real reason instead, before the call is attempted.
+export const MEDIA_FAIL_CAUSE = 'User Denied Media Access'
+
+// Does this browser have a microphone at all? enumerateDevices() needs no permission and does
+// not open the device, and Chromium-family browsers still list one entry per AVAILABLE kind
+// before permission is granted — so a non-empty list with no 'audioinput' is proof there is no
+// microphone. An empty list means the browser is withholding device info, which proves
+// nothing: report 'unknown' rather than warn about a microphone that is probably there.
+export async function audioInputPresence() {
+  const media = navigator.mediaDevices
+  if (!media || !media.getUserMedia) return 'insecure'
+  if (!media.enumerateDevices) return 'unknown'
+  try {
+    const devices = await media.enumerateDevices()
+    if (!devices.length) return 'unknown'
+    return devices.some((device) => device.kind === 'audioinput') ? 'present' : 'none'
+  } catch { return 'unknown' }
+}
+
+// What to tell the user, keyed by the DOMException name the browser reported (or a presence
+// verdict). The returned strings are the i18n keys; the caller translates them.
+export function microphoneMessage(reason) {
+  switch (reason) {
+    case 'none':
+    case 'NotFoundError':
+    case 'DevicesNotFoundError':      // legacy Chrome name for the same condition
+      return 'No microphone was found, so this browser cannot place a call. Connect a microphone or headset — or use a device that has one — and try again.'
+    case 'NotAllowedError':
+    case 'PermissionDeniedError':
+      return 'This site is not allowed to use the microphone, so the call cannot be placed. Allow microphone access for this site in the browser, then try again.'
+    case 'NotReadableError':
+    case 'TrackStartError':
+      return 'The microphone is being held by another application, so the call cannot be placed. Close whatever is using it, then try again.'
+    case 'insecure':
+      return 'Browsers only allow microphone access over HTTPS, so no call can be placed on this address. Open the web interface over HTTPS and try again.'
+    default:
+      return 'The browser could not open the microphone, so the call cannot be placed.'
+  }
+}
+
 export class Softphone {
   // audioEl: a persistent <audio> element rendered by React and handed in via ref. Using one
   // stable, DOM-attached element (instead of a per-call `new Audio()`) is what makes remote
@@ -119,6 +164,10 @@ export class Softphone {
     // -fire events; bind exactly once per session.
     if (session.__vowifiBound) return
     session.__vowifiBound = true
+    // getUserMedia is JsSIP's first step on BOTH an outgoing call() and an answer(), and it
+    // fires the session's 'failed' BEFORE this event — so 'failed' on its own can never say
+    // why a call died in milliseconds. Pass the DOMException name up so the UI can name it.
+    session.on('getusermediafailed', (err) => this.emit('mediafail', (err && err.name) || 'MediaError'))
     const dir = session.direction  // 'incoming' | 'outgoing'
     if (dir === 'incoming') {
       const from = (session.remote_identity && session.remote_identity.uri && session.remote_identity.uri.user) || 'Unknown'

--- a/webui/src/views/Softphone.jsx
+++ b/webui/src/views/Softphone.jsx
@@ -110,11 +110,12 @@ function Avatar({ label, color = 'var(--primary)', size = 96 }) {
   )
 }
 
-function RoundBtn({ icon, label, color, bg, onClick, active }) {
+function RoundBtn({ icon, label, color, bg, onClick, active, disabled = false }) {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 6 }}>
-      <button onClick={onClick} style={{
-        width: 58, height: 58, borderRadius: '50%', cursor: 'pointer', fontSize: 22,
+      <button onClick={disabled ? undefined : onClick} disabled={disabled} style={{
+        width: 58, height: 58, borderRadius: '50%', cursor: disabled ? 'not-allowed' : 'pointer', fontSize: 22,
+        opacity: disabled ? 0.45 : 1,
         border: '1px solid ' + (active ? color : 'var(--border-strong)'),
         background: bg || (active ? color + '22' : 'var(--hover)'),
         color: active ? color : 'var(--text-soft)', display: 'flex', alignItems: 'center', justifyContent: 'center',
@@ -122,6 +123,14 @@ function RoundBtn({ icon, label, color, bg, onClick, active }) {
       <span style={{ fontSize: 11, color: 'var(--text-mute)' }}>{label}</span>
     </div>
   )
+}
+
+// Shown for the whole length of a call that went out on a silent track. The user can hear the
+// call perfectly, so nothing on screen would otherwise suggest they are not being heard.
+function ListenOnlyNote({ t }) {
+  return <div style={{ fontSize: 12, color: '#f59e0b', marginTop: 5 }}>
+    {t('Listen only · the other side cannot hear you')}
+  </div>
 }
 
 export default function Softphone({ selected, subscribe, instances, cards, devices, setSelected, showToast, initialLoading, loadErrors }) {
@@ -138,9 +147,13 @@ export default function Softphone({ selected, subscribe, instances, cards, devic
   const [keypad, setKeypad] = useState(false)
   const [dtmfSeq, setDtmfSeq] = useState('')   // digits/symbols entered since the keypad opened
   const [recording, setRecording] = useState(false)
-  // 'present' | 'none' | 'insecure' | 'unknown'. Starts optimistic so the warning banner can
-  // only ever appear once the probe has actually answered.
+  // 'present' | 'none' | 'insecure' | 'unknown'. Starts optimistic so the notice can only
+  // ever appear once the probe has actually answered.
   const [micPresence, setMicPresence] = useState('present')
+  // Set when THIS call went out on a silent track. Kept per call rather than derived from
+  // micPresence: a call placed before the headset was unplugged is still a normal call, and
+  // one placed after it must keep saying so until it ends.
+  const [listenOnly, setListenOnly] = useState(null)
   const [calls, setCalls] = useState([])
   const [callSelMode, setCallSelMode] = useState(false)
   const [callSel, setCallSel] = useState(() => new Set())
@@ -289,6 +302,8 @@ export default function Softphone({ selected, subscribe, instances, cards, devic
     setKeypad(false); setMuted(false); setRecording(false)
     loadCalls()
   }
+  // The listen-only notice belongs to one call; drop it once the screen goes back to idle.
+  useEffect(() => { if (!call) setListenOnly(null) }, [call])
   // How long the 'ended' screen stays up. A service code's answer is NOT carried by the call:
   // it rides an in-dialog request, is parsed by the manager and arrives over the websocket
   // after the call is already torn down. Clearing on the ordinary 2.5s would hide the very
@@ -347,7 +362,7 @@ export default function Softphone({ selected, subscribe, instances, cards, devic
       else if (type === 'ws') setReg((r) => data === 'connected' ? (r === 'registered' ? r : 'connecting') : 'disconnected')
       else if (type === 'regfail') setReg('failed')
       else if (type === 'incoming') setCall({ dir: 'in', number: data.from || 'Unknown', state: 'incoming', transport: 'vowifi' })
-      else if (type === 'calling') setCall({ dir: 'out', number: data.to, state: 'calling', transport: 'vowifi', serviceCode: isServiceCode(data.to) })
+      else if (type === 'calling') { setListenOnly(null); setCall({ dir: 'out', number: data.to, state: 'calling', transport: 'vowifi', serviceCode: isServiceCode(data.to) }) }
       // 'progress' fires for BOTH directions. On an incoming call JsSIP auto-sends 180 and
       // emits progress('local'); mapping that to 'ringing' would blow away the 'incoming'
       // state and hide the Answer/Decline overlay. Only an OUTGOING call still in the
@@ -356,9 +371,12 @@ export default function Softphone({ selected, subscribe, instances, cards, devic
       else if (type === 'active') setCall((c) => c ? { ...c, state: 'active', startedAt: Date.now() } : c)
       else if (type === 'ended') clearCallSoon(data && data.cause)
       else if (type === 'failed') clearCallSoon(data && data.cause)
-      // The device can also disappear or be grabbed between the pre-dial check and the call
-      // (or on answering an incoming one, which has no pre-dial check at all). 'failed' has
-      // already reset the screen by now; this is what tells the user why.
+      // The call is going out on silence: the carrier is audible, the user is not. Say it
+      // once here and keep saying it on the call screen for as long as the call lasts.
+      else if (type === 'mediafallback') { setListenOnly(data); toast(t(microphoneMessage(data))) }
+      // Last resort: the browser could not even produce a silent track, so JsSIP asked for
+      // the microphone itself and the call really did die. 'failed' has already reset the
+      // screen by now; this is what tells the user why.
       else if (type === 'mediafail') toast(t(microphoneMessage(data)))
     }, audioRef.current)
     ph.start(prov, prov.host || location.hostname)
@@ -516,17 +534,12 @@ export default function Softphone({ selected, subscribe, instances, cards, devic
     }
     if (!phone.current) return
     // Must stay synchronous inside the click: it is the transient user activation that makes
-    // remote audio playable later. Harmless if the microphone check below then aborts.
+    // remote audio playable later.
     phone.current.unlockAudio()
-    // Re-probe rather than trust the banner's state: a microphone can be unplugged between
-    // the page loading and this click.
-    const presence = await audioInputPresence()
-    if (presence === 'none' || presence === 'insecure') {
-      setMicPresence(presence)
-      toast(t(microphoneMessage(presence)))
-      return
-    }
-    phone.current.call(target); setNum('')
+    // A missing microphone does NOT stop the call — it goes out on a silent track and the
+    // phone reports 'mediafallback', which is what puts the listen-only notice on screen.
+    phone.current.call(target)
+    setNum('')
   }
   const answer = () => { phone.current?.unlockAudio(); phone.current?.answer() }
   // Optimistically move to 'ended' on a local hangup. JsSIP will still fire 'ended'
@@ -686,6 +699,7 @@ export default function Softphone({ selected, subscribe, instances, cards, devic
               <div style={{ fontSize: 13, color: 'var(--text-mute)', marginTop: 4 }}>{call.serviceCode
                 ? t('Sending the code to the carrier…')
                 : (call.state === 'ringing' ? t('Ringing…') : t('Calling…'))}</div>
+              {listenOnly && !call.serviceCode && <ListenOnlyNote t={t} />}
             </div>
             <div style={{ display: 'flex', justifyContent: 'center', marginTop: 10 }}>
               <RoundBtn icon="✕" label={t('End')} color="#fff" bg={RED} onClick={hangup} />
@@ -703,6 +717,7 @@ export default function Softphone({ selected, subscribe, instances, cards, devic
                 ? <div style={{ fontSize: 13, color: GREEN, marginTop: 4 }}>{call.ussdText || t('Carrier accepted the code. Waiting for its reply…')}</div>
                 : <div style={{ fontSize: 15, color: GREEN, marginTop: 4, fontVariantNumeric: 'tabular-nums' }}>{fmtDur(dur)}</div>}
               {call.transport === 'cellular' && <div style={{ fontSize: 12, color: '#f59e0b', marginTop: 5 }}>{t('Cellular call connected · browser audio unavailable')}</div>}
+              {listenOnly && call.transport !== 'cellular' && !call.serviceCode && <ListenOnlyNote t={t} />}
               {recording && <div style={{ fontSize: 12, color: RED, marginTop: 2 }}>● Recording</div>}
             </div>
             {call.transport !== 'cellular' && !call.serviceCode && keypad && (
@@ -726,7 +741,8 @@ export default function Softphone({ selected, subscribe, instances, cards, devic
                 signalling that the carrier answers and tears down in about a second. Offering
                 them implies an audio call that is not happening — only Hang up is real here. */}
             {call.transport !== 'cellular' && !call.serviceCode && <div style={{ display: 'flex', justifyContent: 'center', gap: 22, marginTop: 8 }}>
-              <RoundBtn icon={muted ? '🔇' : '🎙'} label={t(muted ? 'Unmute' : 'Mute')} color="#60a5fa" onClick={toggleMute} active={muted} />
+              <RoundBtn icon={listenOnly ? '🚫' : muted ? '🔇' : '🎙'} label={t(listenOnly ? 'No mic' : muted ? 'Unmute' : 'Mute')}
+                color="#60a5fa" onClick={toggleMute} active={muted} disabled={Boolean(listenOnly)} />
               <RoundBtn icon="⌨" label={t('Keypad')} color="#a78bfa" onClick={() => setKeypad((v) => !v)} active={keypad} />
               <RoundBtn icon="⏺" label={t(recording ? 'Stop' : 'Record')} color={RED} onClick={toggleRecord} active={recording} />
             </div>}

--- a/webui/src/views/Softphone.jsx
+++ b/webui/src/views/Softphone.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react'
 import { api } from '../api.js'
-import { Softphone as Phone } from '../softphone.js'
+import { Softphone as Phone, audioInputPresence, microphoneMessage, MEDIA_FAIL_CAUSE } from '../softphone.js'
 import SimSelector from './SimSelector.jsx'
 import { useI18n } from '../i18n.jsx'
 
@@ -138,6 +138,9 @@ export default function Softphone({ selected, subscribe, instances, cards, devic
   const [keypad, setKeypad] = useState(false)
   const [dtmfSeq, setDtmfSeq] = useState('')   // digits/symbols entered since the keypad opened
   const [recording, setRecording] = useState(false)
+  // 'present' | 'none' | 'insecure' | 'unknown'. Starts optimistic so the warning banner can
+  // only ever appear once the probe has actually answered.
+  const [micPresence, setMicPresence] = useState('present')
   const [calls, setCalls] = useState([])
   const [callSelMode, setCallSelMode] = useState(false)
   const [callSel, setCallSel] = useState(() => new Set())
@@ -353,6 +356,10 @@ export default function Softphone({ selected, subscribe, instances, cards, devic
       else if (type === 'active') setCall((c) => c ? { ...c, state: 'active', startedAt: Date.now() } : c)
       else if (type === 'ended') clearCallSoon(data && data.cause)
       else if (type === 'failed') clearCallSoon(data && data.cause)
+      // The device can also disappear or be grabbed between the pre-dial check and the call
+      // (or on answering an incoming one, which has no pre-dial check at all). 'failed' has
+      // already reset the screen by now; this is what tells the user why.
+      else if (type === 'mediafail') toast(t(microphoneMessage(data)))
     }, audioRef.current)
     ph.start(prov, prov.host || location.hostname)
     phone.current = ph
@@ -364,6 +371,18 @@ export default function Softphone({ selected, subscribe, instances, cards, devic
   // The <audio> element mounts with the component; make sure the phone (which may have been
   // created before the ref attached) points at it.
   useEffect(() => { if (phone.current && audioRef.current) phone.current.setAudioEl(audioRef.current) })
+
+  // Probe for a microphone once, and again whenever the set of devices changes (a headset
+  // plugged in should clear the warning without a reload). enumerateDevices() prompts for
+  // nothing and opens nothing, so this is free to run on mount.
+  useEffect(() => {
+    let alive = true
+    const probe = () => { audioInputPresence().then((p) => { if (alive) setMicPresence(p) }).catch(() => {}) }
+    probe()
+    const media = navigator.mediaDevices
+    media?.addEventListener?.('devicechange', probe)
+    return () => { alive = false; media?.removeEventListener?.('devicechange', probe) }
+  }, [])
 
   // in-call duration timer
   useEffect(() => {
@@ -460,6 +479,16 @@ export default function Softphone({ selected, subscribe, instances, cards, devic
       toast(t('This browser has WebRTC disabled, so no call can be placed. A privacy or ad-blocking extension is the usual cause — allow WebRTC for this site, or open it in a private window.'))
       return
     }
+    // The status dot already says the line is down, but the Call button did not read it: the
+    // INVITE went into a websocket that is not there and the screen reported an ordinary
+    // failed call. 'connecting' is deliberately allowed through — the transport may come up
+    // within the call setup — while these three states cannot carry a call at all.
+    if (callTransport === 'vowifi' && ['disconnected', 'failed', 'unregistered'].includes(reg)) {
+      toast(t(reg === 'disconnected'
+        ? 'This browser is not connected to the line’s engine, so the call cannot be placed. Check that the engine for this SIM is running.'
+        : 'This line is not registered right now, so the call cannot be placed. Wait for the Registered indicator, or check the line’s VoWiFi status.'))
+      return
+    }
     if (callTransport === 'cellular') {
       // The cellular backend places a voice call. A service code is supplementary-service
       // signalling, which needs AT+CUSD instead, so fail loudly rather than dialling nonsense.
@@ -486,7 +515,18 @@ export default function Softphone({ selected, subscribe, instances, cards, devic
       return
     }
     if (!phone.current) return
-    phone.current.unlockAudio(); phone.current.call(target); setNum('')
+    // Must stay synchronous inside the click: it is the transient user activation that makes
+    // remote audio playable later. Harmless if the microphone check below then aborts.
+    phone.current.unlockAudio()
+    // Re-probe rather than trust the banner's state: a microphone can be unplugged between
+    // the page loading and this click.
+    const presence = await audioInputPresence()
+    if (presence === 'none' || presence === 'insecure') {
+      setMicPresence(presence)
+      toast(t(microphoneMessage(presence)))
+      return
+    }
+    phone.current.call(target); setNum('')
   }
   const answer = () => { phone.current?.unlockAudio(); phone.current?.answer() }
   // Optimistically move to 'ended' on a local hangup. JsSIP will still fire 'ended'
@@ -544,7 +584,11 @@ export default function Softphone({ selected, subscribe, instances, cards, devic
   const inCall = call && (call.state === 'active' || call.state === 'calling' || call.state === 'ringing' || call.state === 'incoming' || call.state === 'ended')
   const endLabel = (c, isCode) => (isCode
     ? t(SERVICE_CODE_END_LABEL[c] || 'The carrier gave no usable answer to this code.')
-    : t(c === 'Rejected' ? 'Call declined' : c === 'Busy' ? 'Busy' : c === 'Canceled' || c === 'Canceled/Rejected' ? 'Call cancelled' : 'Call ended'))
+    // A local media failure never reached the carrier, so reporting it as a plain "Call
+    // ended" describes the one thing that did NOT happen. Name it: the toast explains what
+    // to do about it, and this line stops the screen from blaming the call.
+    : t(c === MEDIA_FAIL_CAUSE ? 'Microphone unavailable'
+      : c === 'Rejected' ? 'Call declined' : c === 'Busy' ? 'Busy' : c === 'Canceled' || c === 'Canceled/Rejected' ? 'Call cancelled' : 'Call ended'))
 
   // Google-Voice-style incoming-call overlay (prominent, full-panel)
   const IncomingOverlay = call?.state === 'incoming' ? (
@@ -614,6 +658,12 @@ export default function Softphone({ selected, subscribe, instances, cards, devic
           <div style={{ margin: '12px 0', padding: '10px 12px', borderRadius: 8, fontSize: 13,
             lineHeight: 1.5, color: '#b45309', background: '#fffbeb', border: '1px solid #fcd34d' }}>
             {t('This browser has WebRTC disabled, so no call can be placed. A privacy or ad-blocking extension is the usual cause — allow WebRTC for this site, or open it in a private window.')}
+          </div>
+        )}
+        {callTransport === 'vowifi' && (micPresence === 'none' || micPresence === 'insecure') && (
+          <div style={{ margin: '12px 0', padding: '10px 12px', borderRadius: 8, fontSize: 13,
+            lineHeight: 1.5, color: '#b45309', background: '#fffbeb', border: '1px solid #fcd34d' }}>
+            {t(microphoneMessage(micPresence))}
           </div>
         )}
         {callTransport === 'vowifi' && prov && !prov.enabled && (


### PR DESCRIPTION
Fixes #90.

## What was happening

The report was "click dial, instant disconnect". The reporter's own console log had the
answer in it, one line below the part they quoted:

```
JsSIP:RTCSession session failed +11ms
JsSIP:WARN:RTCSession emit "getusermediafailed" [error:NotFoundError: Requested device not found]
```

`getUserMedia` is JsSIP's *first* step, so the session died ~11ms after the click with no
INVITE ever sent: that browser has no microphone (`NotFoundError` means no device — a denied
permission would be `NotAllowedError`). JsSIP reports every media failure as the one cause
`User Denied Media Access`, and `endLabel` collapsed anything it did not recognise into
"Call ended" — i.e. the UI described a purely local failure as a completed call, which reads
as a carrier problem. That is why the reporter went hunting for the missing WSS ports
instead; those (8109/8119) were just two of their own engine containers not running, and are
not part of this fix.

## What changed

WebRTC needs a local audio track, not a microphone. A call with no microphone still carries
the carrier's audio, which is the whole point of dialling a voicemail box, a service code or
an announcement — so the microphone decides how the call sounds, not whether it happens.

- `_acquireLocal()` takes over the media step from JsSIP: a real stream when `getUserMedia`
  succeeds, and a silent one (`AudioContext` → `MediaStreamDestination`, oscillator at zero
  gain so the graph actually produces frames) when it does not. Either way the stream is
  passed to JsSIP as `mediaStream`, which skips its own `getUserMedia` and the session-killing
  failure path behind it. Applies to `answer()` as well, so an incoming call is answerable
  without a microphone too.
- A stream we pass in is ours to release — JsSIP only stops tracks it generated itself — so
  it is stopped on `ended`/`failed`/`hangup()`, and the AudioContext closed with it. Without
  that the browser's recording indicator would stay lit after every call.
- Every surface says what the call got: an idle notice on the dialler (from a permission-free
  `enumerateDevices()` probe that re-runs on `devicechange`), a "Listen only · the other side
  cannot hear you" line on both the ringing and the connected screen for the whole call, the
  same line on the global incoming-call overlay, and a toast naming the reason — no device,
  blocked by permission, held by another application, or a non-HTTPS address.
- Mute is disabled while listen-only. A toggle that cannot change anything reads as a broken
  button.
- `unlockAudio()` still runs synchronously on the click, before `call()` awaits the media, so
  the transient user activation that makes remote audio playable is not lost.
- If even a silent track cannot be built, JsSIP asks for the microphone itself and the call
  does die — that path is still named ("Microphone unavailable") rather than "Call ended".
- While here: the Call button now reads the registration state it already draws. It was
  sending an INVITE into a disconnected websocket and then reporting an ordinary failed call.
  `connecting` is still allowed through; only `disconnected`/`failed`/`unregistered` block.

## Verification

- `python -m unittest discover -s tests` — 1132 tests, OK (16 new in
  `tests/test_ui_softphone_media_preflight.py`).
- `npm run build` in `webui/` — clean.

Not covered here: why the reporter's engine-3/engine-4 containers were not running, and
gating the global softphone's UAs on engine state (that is what filled their console with
retries to 8109/8119). Out of scope by request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)